### PR TITLE
fix: parsing of .cjs files as .js

### DIFF
--- a/lib/common.ts
+++ b/lib/common.ts
@@ -89,7 +89,7 @@ export function isPackageJson(file: string) {
 }
 
 export function isDotJS(file: string) {
-  return path.extname(file) === '.js';
+  return ['.js', '.cjs'].includes(path.extname(file));
 }
 
 export function isDotJSON(file: string) {


### PR DESCRIPTION
This pull request fixes the issue where .cjs files were not being correctly parsed as .js files. The `isDotJS` function has been updated to include the .cjs extension in the check.