### PR TITLE
fix: add missing arch to nativePrebuildInstall cache

### DIFF
--- a/lib/producer.ts
+++ b/lib/producer.ts
@@ -210,7 +210,7 @@ function nativePrebuildInstall(target: Target, nodeFile: string) {
     throw new Error(`Couldn't find node version, instead got: ${nodeVersion}`);
   }
 
-  const nativeFile = `${nodeFile}.${target.platform}.${nodeVersion}`;
+  const nativeFile = `${nodeFile}.${target.platform}.${target.arch}.${nodeVersion}`;
 
   if (fs.existsSync(nativeFile)) {
     return nativeFile;


### PR DESCRIPTION
Otherwise when packaging for multiple architectures, pkg might end up picking up a cached binary for a different arch.

In general that code is a bit finicky and it will only really work for packages that actually use `prebuild-install`, and currently also fails for any prebuild napi package, as you need to pass `-r/--runtime napi` to `prebuild-install` for that to work, which is a different bug. 

I'm currently just doing my own workarounds for native packages that this doesn't handle (e.g. `pnpm rebuild`, or `pnpm install --force`, before invoking `pkg` per target, rather than for all targets at once. It would have been much nicer if there was a more general way to handle this or to give per package hooks to `pkg` to handle packages with special requirements.

Contributed on behalf of [Swimm](https://swimm.io/)