### PR TITLE
fix: over extracting native modules with pnpm

### DIFF
--- a/prelude/bootstrap.js
+++ b/prelude/bootstrap.js
@@ -2217,7 +2217,7 @@ function payloadFileSync(pointer) {
 
       // Example: moduleFolder = /snapshot/appname/node_modules/sharp/build/Release
       const parts = moduleFolder.split(path.sep);
-      const mIndex = parts.indexOf('node_modules') + 1;
+      const mIndex = parts.lastIndexOf('node_modules') + 1;
 
       let newPath;
 


### PR DESCRIPTION
pnpm results in bundling paths like `/snapshot/node_modules/.pnpm/foobar@0.1.0/node_modules/foobar/build/Release/foobar.node`

So use the last `node_modules` instead of the first to figure out what to extract so as to not extract the entire `.pnpm` folder.

Contributed on behalf of [Swimm](https://swimm.io/)