### PR TITLE
fix: pass `--runtime napi` to `prebuild-install` when `binary.napi_versions` is set

### DIFF
--- a/lib/producer.ts
+++ b/lib/producer.ts
@@ -235,6 +235,8 @@ function nativePrebuildInstall(target: Target, nodeFile: string) {
   if (napiVersions == null) {
     // TODO: consider target node version and supported n-api version
     options.push('--target', nodeVersion);
+  } else {
+    options.push('--runtime', 'napi');
   }
 
   // run prebuild


### PR DESCRIPTION
Many modules that use prebuild just pass `-r napi` and don't have `config.runtime` set in their `package.json` which doesn't even seem to be documented