### PR TITLE
fix: use cache directory in users home instead of system-wide tmp dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,14 +353,14 @@ This way you may even avoid creating `pkg` config for your project.
 Native addons (`.node` files) use is supported. When `pkg` encounters
 a `.node` file in a `require` call, it will package this like an asset.
 In some cases (like with the `bindings` package), the module path is generated
-dynamicaly and `pkg` won't be able to detect it. In this case, you should
+dynamically and `pkg` won't be able to detect it. In this case, you should
 add the `.node` file directly in the `assets` field in `package.json`.
 
 The way Node.js requires native addon is different from a classic JS
 file. It needs to have a file on disk to load it, but `pkg` only generates
-one file. To circumvent this, `pkg` will create a temporary file on the
-disk. These files will stay on the disk after the process has exited
-and will be used again on the next process launch.
+one file. To circumvent this, `pkg` will extract native addon files to
+`$HOME/.cache/pkg/`. These files will stay on the disk after the process has
+exited and will be used again on the next process launch.
 
 When a package, that contains a native module, is being installed,
 the native module is compiled against current system-wide Node.js

--- a/prelude/bootstrap.js
+++ b/prelude/bootstrap.js
@@ -2210,7 +2210,7 @@ function payloadFileSync(pointer) {
       // the hash is needed to be sure we reload the module in case it changes
       const hash = createHash('sha256').update(moduleContent).digest('hex');
 
-      // Example: /tmp/pkg/<hash>
+      // Example: /home/john/.cache/pkg/<hash>
       const tmpFolder = path.join(homedir(), '.cache/pkg', hash);
 
       createDirRecursively(tmpFolder);

--- a/prelude/bootstrap.js
+++ b/prelude/bootstrap.js
@@ -24,7 +24,7 @@ const Module = require('module');
 const path = require('path');
 const { promisify, _extend } = require('util');
 const { Script } = require('vm');
-const { tmpdir } = require('os');
+const { homedir } = require('os');
 const util = require('util');
 const {
   brotliDecompress,
@@ -2211,7 +2211,7 @@ function payloadFileSync(pointer) {
       const hash = createHash('sha256').update(moduleContent).digest('hex');
 
       // Example: /tmp/pkg/<hash>
-      const tmpFolder = path.join(tmpdir(), 'pkg', hash);
+      const tmpFolder = path.join(homedir(), '.cache/pkg', hash);
 
       createDirRecursively(tmpFolder);
 


### PR DESCRIPTION
Using a cache directory in users home directory fixes problems with conflicting user permissions and is also more secure because other users cannot inject executable code by placing a manipulated file in tmp.

Fixes  #51