### PR TITLE
fix: remove `is-core-module` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "fs-extra": "^9.1.0",
     "globby": "^11.1.0",
     "into-stream": "^6.0.0",
-    "is-core-module": "2.9.0",
     "minimatch": "9.0.4",
     "minimist": "^1.2.6",
     "multistream": "^4.1.0",
@@ -43,7 +42,6 @@
     "@release-it/conventional-changelog": "7.0.2",
     "@types/babel__generator": "7.6.5",
     "@types/fs-extra": "9.0.13",
-    "@types/is-core-module": "2.2.0",
     "@types/minimatch": "^5.1.2",
     "@types/minimist": "1.2.2",
     "@types/multistream": "4.1.0",
@@ -141,5 +139,6 @@
   },
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "packageManager": "yarn@1.22.22"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -516,11 +516,6 @@
   resolved "https://registry.yarnpkg.com/@types/http-cache-semantics/-/http-cache-semantics-4.0.4.tgz#b979ebad3919799c979b17c72621c0bc0a31c6c4"
   integrity sha512-1m0bIFVc7eJWyve9S0RnuRgcQqF/Xd5QsUZAZeQFr1Q3/p9JWoQQEqmVy+DPTNpGXwhgIetAoYF8JSc33q29QA==
 
-"@types/is-core-module@2.2.0":
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/@types/is-core-module/-/is-core-module-2.2.0.tgz#a6f01308db449fb9200cc8b8b05aa26f404f0ddb"
-  integrity sha512-4jdbEoadP1B6v5/6YoVFPKUr2NC+knEWMSllpX3cL4FAZktVmveeWTcUHQY7bU6Vx8TEt/ARbQyQapkZvGgFog==
-
 "@types/json-schema@^7.0.12":
   version "7.0.15"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.15.tgz#596a1747233694d50f6ad8a7869fcb6f56cf5841"
@@ -2720,13 +2715,6 @@ is-ci@3.0.1, is-ci@^3.0.1:
   integrity sha512-ZYvCgrefwqoQ6yTyYUbQu64HsITZ3NfKX1lzaEYdkTDcfKzzCI/wthRRYKkdjHKFVgNiXKAKm65Zo1pk2as/QQ==
   dependencies:
     ci-info "^3.2.0"
-
-is-core-module@2.9.0:
-  version "2.9.0"
-  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.9.0.tgz#e1c34429cd51c6dd9e09e0799e396e27b19a9c69"
-  integrity sha512-+5FPy5PnwmO3lvfMb0AsoPaBG+5KHUI0wYFXOtYPnVVVspTFUuMZNfNaNVRt3FZadstu2c8x23vykRW/NBoU6A==
-  dependencies:
-    has "^1.0.3"
 
 is-core-module@^2.13.0, is-core-module@^2.8.1:
   version "2.13.1"


### PR DESCRIPTION
Follow-up after answer in https://github.com/yao-pkg/pkg/discussions/76.

Node.js from v6.13.0, v8.10.0, v9.3.0 includes `module.builtinModules` which we can use to natively check if some module belongs to Node.js core or not. 

This drops not one, but _three_ dependencies from `pkg`, removing 70 KB of bloat: https://npmgraph.js.org/?q=is-core-module