### PR TITLE
fix: child_process commands throw when pkg app try to call itself

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,6 +402,23 @@ await exec(['app.js', '--target', 'host', '--output', 'app.exe']);
 
 ## Troubleshooting
 
+### Error: Cannot find module XXX (when using `child_process`)
+
+When using `child_process` methods to run a new process pkg by default will invoke it using NodeJS runtime that is built into the executable. This means that if you are trying to spawn the packaged app itself you will get above error. In order to avoid this you must set `PKG_EXECPATH` env set to `""`:
+
+```js
+const { spawn } = require('child_process');
+
+const child = spawn(process.execPath, [process.argv[1]], {
+  env: {
+    ...process.env,
+    PKG_EXECPATH: '',
+  },
+});
+```
+
+More info [here](https://github.com/yao-pkg/pkg/pull/90)
+
 ### Error: ENOENT: no such file or directory, uv_chdir
 
 This error can be caused by deleting the directory the application is

--- a/prelude/bootstrap.js
+++ b/prelude/bootstrap.js
@@ -2006,6 +2006,7 @@ function payloadFileSync(pointer) {
     }
     const opts = args[pos];
     if (!opts.env) opts.env = _extend({}, process.env);
+    // see https://github.com/vercel/pkg/issues/897#issuecomment-1049370335
     if (opts.env.PKG_EXECPATH !== undefined) return;
     opts.env.PKG_EXECPATH = EXECPATH;
   }

--- a/prelude/bootstrap.js
+++ b/prelude/bootstrap.js
@@ -2006,7 +2006,7 @@ function payloadFileSync(pointer) {
     }
     const opts = args[pos];
     if (!opts.env) opts.env = _extend({}, process.env);
-    if (opts.env.PKG_EXECPATH === 'PKG_INVOKE_NODEJS') return;
+    if (opts.env.PKG_EXECPATH !== undefined) return;
     opts.env.PKG_EXECPATH = EXECPATH;
   }
 


### PR DESCRIPTION
Now in order to allow this you have to add `PKG_EXECPATH` env var set to `""`. Thanks to @edvald solution proposed [here](https://github.com/vercel/pkg/issues/897#issuecomment-1049370335)

Fixes #70