### PR TITLE
fix: follow exact SEA baking procedure for Mac

### DIFF
--- a/lib/mach-o.ts
+++ b/lib/mach-o.ts
@@ -32,6 +32,11 @@ function patchCommand(type: number, buf: Buffer, file: Buffer) {
   }
 }
 
+/**
+ * It would be nice to explain the purpose of this patching function
+ * @param file
+ * @returns
+ */
 function patchMachOExecutable(file: Buffer) {
   const align = 8;
   const hsize = 32;
@@ -67,4 +72,14 @@ function signMachOExecutable(executable: string) {
   }
 }
 
-export { patchMachOExecutable, signMachOExecutable };
+function removeMachOExecutableSignature(executable: string) {
+  execFileSync('codesign', ['--remove-signature', executable], {
+    stdio: 'inherit',
+  });
+}
+
+export {
+  patchMachOExecutable,
+  removeMachOExecutableSignature,
+  signMachOExecutable,
+};

--- a/test/test-00-sea/main.js
+++ b/test/test-00-sea/main.js
@@ -28,12 +28,11 @@ if (process.platform === 'linux') {
     'Output matches',
   );
 } else if (process.platform === 'darwin') {
-  // FIXME: not working, needs investigation
-  // assert.equal(
-  //   utils.spawn.sync('./test-sea-macos', []),
-  //   'Hello world\n',
-  //   'Output matches',
-  // );
+  assert.equal(
+    utils.spawn.sync('./test-sea-macos', []),
+    'Hello world\n',
+    'Output matches',
+  );
 } else if (process.platform === 'win32') {
   // FIXME: output doesn't match on windows
   // assert.equal(


### PR DESCRIPTION
Followed the process described in [Node.js docs](https://nodejs.org/api/single-executable-applications.html#generating-single-executable-preparation-blobs) to produce valid binaries for your beloved MacOS fan-base :D.

I tested this locally by patching pkg in one of my repository.
Once my Webpack configuration was adapted to bundle the `node_modules` into the build output, and after running `npx pkg main.js --output main -t node20-macos-arm64 --sea --debug`, the application was running 🎉.

Maybe you can guide me, and tell me where should the tests be written?