### PR TITLE
fix: deprecated `_extend` in bootstrap.js

### DIFF
--- a/prelude/bootstrap.js
+++ b/prelude/bootstrap.js
@@ -22,7 +22,7 @@ const fs = require('fs');
 const { isRegExp } = require('util').types;
 const Module = require('module');
 const path = require('path');
-const { promisify, _extend } = require('util');
+const { promisify } = require('util');
 const { Script } = require('vm');
 const { homedir } = require('os');
 const util = require('util');
@@ -2005,7 +2005,7 @@ function payloadFileSync(pointer) {
       args.splice(pos, 0, {});
     }
     const opts = args[pos];
-    if (!opts.env) opts.env = _extend({}, process.env);
+    if (!opts.env) opts.env = Object.assign({}, process.env);
     // see https://github.com/vercel/pkg/issues/897#issuecomment-1049370335
     if (opts.env.PKG_EXECPATH !== undefined) return;
     opts.env.PKG_EXECPATH = EXECPATH;

--- a/prelude/bootstrap.js
+++ b/prelude/bootstrap.js
@@ -2005,7 +2005,7 @@ function payloadFileSync(pointer) {
       args.splice(pos, 0, {});
     }
     const opts = args[pos];
-    if (!opts.env) opts.env = Object.assign({}, process.env);
+    if (!opts.env) opts.env = { ...process.env };
     // see https://github.com/vercel/pkg/issues/897#issuecomment-1049370335
     if (opts.env.PKG_EXECPATH !== undefined) return;
     opts.env.PKG_EXECPATH = EXECPATH;


### PR DESCRIPTION
Use of deprecated `_extend` function causes Node to display a deprecation warning when executing the standalone binary package.