### PR TITLE
fix: upgrade tinyglobby

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "resolve": "^1.22.0",
     "stream-meter": "^1.0.4",
     "tar": "^7.4.3",
-    "tinyglobby": "^0.2.9",
+    "tinyglobby": "^0.2.11",
     "unzipper": "^0.12.3"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2137,10 +2137,10 @@ fastq@^1.6.0:
   dependencies:
     reusify "^1.0.4"
 
-fdir@^6.4.2:
-  version "6.4.2"
-  resolved "https://registry.yarnpkg.com/fdir/-/fdir-6.4.2.tgz#ddaa7ce1831b161bc3657bb99cb36e1622702689"
-  integrity sha512-KnhMXsKSPZlAhp7+IjUkRZKPb4fUyccpDrdFXbi4QL1qkmFh9kVY09Yox+n4MaOb3lHZ1Tv829C3oaaXoMYPDQ==
+fdir@^6.4.3:
+  version "6.4.3"
+  resolved "https://registry.yarnpkg.com/fdir/-/fdir-6.4.3.tgz#011cdacf837eca9b811c89dbb902df714273db72"
+  integrity sha512-PMXmW2y1hDDfTSRc9gaXIuCCRpuoz3Kaz8cUelp3smouvfT632ozg2vrT6lJsHKKOF59YLbOGfAWGUcKEfRMQw==
 
 fetch-blob@^3.1.2, fetch-blob@^3.1.4:
   version "3.2.0"
@@ -4678,12 +4678,12 @@ text-table@^0.2.0:
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
   integrity sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==
 
-tinyglobby@^0.2.9:
-  version "0.2.10"
-  resolved "https://registry.yarnpkg.com/tinyglobby/-/tinyglobby-0.2.10.tgz#e712cf2dc9b95a1f5c5bbd159720e15833977a0f"
-  integrity sha512-Zc+8eJlFMvgatPZTl6A9L/yht8QqdmUNtURHaKZLmKBE12hNPSrqNkUp2cs3M/UKmNVVAMFQYSjYIVHDjW5zew==
+tinyglobby@^0.2.11:
+  version "0.2.11"
+  resolved "https://registry.yarnpkg.com/tinyglobby/-/tinyglobby-0.2.11.tgz#9182cff655a0e272aad850d1a84c5e8e0f700426"
+  integrity sha512-32TmKeeKUahv0Go8WmQgiEp9Y21NuxjwjqiRC1nrUB51YacfSwuB44xgXD+HdIppmMRgjQNPdrHyA6vIybYZ+g==
   dependencies:
-    fdir "^6.4.2"
+    fdir "^6.4.3"
     picomatch "^4.0.2"
 
 titleize@^3.0.0:


### PR DESCRIPTION
fixes #119

the problem with glob usage in this project is that `globSync` is called multiple times which isn't optimal, as it forces `tinyglobby` to traverse the filesystem multiple times. in theory, `globSync` could be called just once during the walking process, but that would be a bigger refactor, although a possible one

EDIT: this pr upgrades tinyglobby, ignore the text below this

it looks like under a default config most patterns passed to `globSync` aren't even globs, so this PR avoids unnecessary `globSync` calls when none of the patterns are globs

<details><summary>screenshot of patterns passed to tinyglobby in 6.1.0, each log is a different glob call</summary>

![image](https://github.com/user-attachments/assets/b3b4f080-db54-4504-a336-191ec50cd8c4)
</details> 

locally (windows) this change makes it faster than 5.15.0, with the reproduction from #119 taking 25s in 5.15.0 and 13s in latest with the change (latest without the change took too long to measure)