### PR TITLE
fix: revert "refactor: replace `globby` with `tinyglobby` (#103)"

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ use of `package.json` configuration.
 
 ### Scripts
 
-`scripts` is a [glob](https://github.com/SuperchupuDev/tinyglobby)
+`scripts` is a [glob](https://github.com/sindresorhus/globby)
 or list of globs. Files specified as `scripts` will be compiled
 using `v8::ScriptCompiler` and placed into executable without
 sources. They must conform to the JS standards of those Node.js versions
@@ -168,7 +168,7 @@ you target (see [Targets](#targets)), i.e. be already transpiled.
 
 ### Assets
 
-`assets` is a [glob](https://github.com/SuperchupuDev/tinyglobby)
+`assets` is a [glob](https://github.com/sindresorhus/globby)
 or list of globs. Files specified as `assets` will be packaged
 into executable as raw content without modifications. Javascript
 files may also be specified as `assets`. Their sources will

--- a/lib/walker.ts
+++ b/lib/walker.ts
@@ -2,10 +2,10 @@
 
 import assert from 'assert';
 import fs from 'fs/promises';
+import globby from 'globby';
 import path from 'path';
 import { builtinModules } from 'module';
 import picomatch from 'picomatch';
-import { globSync } from 'tinyglobby';
 
 import {
   ALIAS_AS_RELATIVE,
@@ -194,7 +194,7 @@ function upon(p: string, base: string) {
 }
 
 function collect(ps: string[]) {
-  return globSync(ps, { absolute: true, dot: true });
+  return globby.sync(ps, { dot: true });
 }
 
 function expandFiles(efs: string | string[], base: string) {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@babel/parser": "^7.23.0",
     "@babel/types": "^7.23.0",
     "@yao-pkg/pkg-fetch": "3.5.17",
+    "globby": "11.1.0",
     "into-stream": "^6.0.0",
     "minimist": "^1.2.6",
     "multistream": "^4.1.0",
@@ -35,7 +36,6 @@
     "resolve": "^1.22.0",
     "stream-meter": "^1.0.4",
     "tar": "^7.4.3",
-    "tinyglobby": "^0.2.9",
     "unzipper": "^0.12.3"
   },
   "devDependencies": {

--- a/test/test-79-npm/main.js
+++ b/test/test-79-npm/main.js
@@ -11,7 +11,7 @@ const UPM = process.env.USE_PREINSTALLED_MODULES || false; // USE_PREINSTALLED_M
 const fs = require('fs');
 const path = require('path');
 const assert = require('assert');
-const { globSync } = require('tinyglobby');
+const globby = require('globby');
 const utils = require('../utils.js');
 
 assert(!module.parent);
@@ -127,12 +127,19 @@ if (!UPM) {
 })();
 
 // note to developpers:
-// you can set the env variable FILTER to something like "better-sqlite3/*.js"
+// you can set the  env variable FILTER to something like "better-sqlite3/*.js"
 // to restrict this test to this single test case
-const inputs = globSync([process.env.FILTER || '*/*.js'], {
-  absolute: true,
-  ignore: ['*/*.config.js', '*/*.meta.js', '*/gulpfile.js', '*/*fixture*'],
-}).map((p) => path.normalize(p));
+const inputs = globby
+  .sync([
+    process.env.FILTER || './*/*.js',
+    '!./*/*.config.js',
+    '!./*/*.meta.js',
+    '!./*/gulpfile.js',
+    '!./*/*fixture*',
+  ])
+  .map(function (result) {
+    return path.resolve(result);
+  });
 
 let times = {};
 const ci = process.env.CI;
@@ -302,14 +309,14 @@ inputs.some(function (input) {
     const deployFiles = [];
 
     if (!meta.deployFiles && !meta.deployFilesFrom) {
-      globSync(path.join(foldy, 'node_modules', '**', '*.node')).some(
-        function (deployFrom) {
+      globby
+        .sync(path.join(foldy, 'node_modules', '**', '*.node'))
+        .some(function (deployFrom) {
           deployFiles.push([
             deployFrom,
             path.join(path.dirname(output), path.basename(deployFrom)),
           ]);
-        },
-      );
+        });
     }
 
     const deployFilesRelative = [];
@@ -355,8 +362,9 @@ inputs.some(function (input) {
         if (statFrom.isFile()) {
           deployFiles.push([deployFrom, deployTo]);
         } else {
-          globSync(path.join(deployFrom, '**', '*')).some(
-            function (deployFrom2) {
+          globby
+            .sync(path.join(deployFrom, '**', '*'))
+            .some(function (deployFrom2) {
               const r = path.relative(deployFrom, deployFrom2);
               const deployTo2 = path.join(deployTo, r);
               if (fs.existsSync(deployFrom2)) {
@@ -365,8 +373,7 @@ inputs.some(function (input) {
                   deployFiles.push([deployFrom2, deployTo2]);
                 }
               }
-            },
-          );
+            });
         }
       }
     });
@@ -404,7 +411,7 @@ inputs.some(function (input) {
     }
   }
 
-  const rubbishes = globSync(path.join(path.dirname(output), '**', '*'));
+  const rubbishes = globby.sync(path.join(path.dirname(output), '**', '*'));
 
   rubbishes.some(function (rubbish) {
     utils.vacuum.sync(rubbish);

--- a/test/test-80-compression-node-opcua/main.js
+++ b/test/test-80-compression-node-opcua/main.js
@@ -14,12 +14,6 @@ const assert = require('assert');
 const utils = require('../utils.js');
 const pkgJson = require('./package.json');
 
-// FIXME: this test takes a long time to run (from 5min on linux up to 10 minuntes on windows)
-// run only on linux to save time on CI
-if (process.platform !== 'linux') {
-  return;
-}
-
 const isWindows = process.platform === 'win32';
 const buildDir = 'build';
 

--- a/test/test.js
+++ b/test/test.js
@@ -2,9 +2,9 @@
 
 'use strict';
 
+const globby = require('globby');
 const path = require('path');
 const pc = require('picocolors');
-const { globSync } = require('tinyglobby');
 const utils = require('./utils.js');
 const { spawn } = require('child_process');
 const host = 'node' + utils.getNodeMajorVersion();
@@ -53,7 +53,6 @@ function joinAndForward(d) {
 }
 
 const list = [];
-const ignore = [];
 
 // test that should be run on `host` target only
 const npmTests = [
@@ -80,14 +79,14 @@ if (flavor.match(/^test/)) {
   list.push(joinAndForward('**/main.js'));
   if (flavor === 'no-npm') {
     // TODO: fix this test
-    ignore.push(joinAndForward('test-79-npm'));
+    list.push('!' + joinAndForward('test-79-npm'));
     npmTests.forEach((t) => {
-      ignore.push(joinAndForward(t));
+      list.push('!' + joinAndForward(t));
     });
   }
 }
 
-const files = globSync(list, { ignore });
+const files = globby.sync(list);
 
 function msToHumanDuration(ms) {
   if (ms < 1000) return `${ms}ms`;

--- a/test/utils.js
+++ b/test/utils.js
@@ -3,7 +3,7 @@
 const assert = require('assert');
 const path = require('path');
 const rimraf = require('rimraf');
-const { globSync } = require('tinyglobby');
+const globby = require('globby');
 const { execSync, spawnSync } = require('child_process');
 const {
   existsSync,
@@ -194,7 +194,7 @@ module.exports.filesBefore = function (n) {
   for (const ni of n) {
     module.exports.vacuum.sync(ni);
   }
-  return globSync('**/*').sort();
+  return globby.sync('**/*', { nodir: true }).sort();
 };
 
 /**
@@ -204,10 +204,7 @@ module.exports.filesBefore = function (n) {
  * @param {string[]} newComers New files produced by test that should be removed
  */
 module.exports.filesAfter = function (before, newComers) {
-  // actual files in the directory
-  const a = globSync('**/*').sort();
-
-  // check that all files in `b` exist, otherwise fail
+  const a = globby.sync('**/*', { nodir: true }).sort();
   for (const bi of before) {
     if (a.indexOf(bi) < 0) {
       assert(false, `${bi} disappeared!?`);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2137,11 +2137,6 @@ fastq@^1.6.0:
   dependencies:
     reusify "^1.0.4"
 
-fdir@^6.4.2:
-  version "6.4.2"
-  resolved "https://registry.yarnpkg.com/fdir/-/fdir-6.4.2.tgz#ddaa7ce1831b161bc3657bb99cb36e1622702689"
-  integrity sha512-KnhMXsKSPZlAhp7+IjUkRZKPb4fUyccpDrdFXbi4QL1qkmFh9kVY09Yox+n4MaOb3lHZ1Tv829C3oaaXoMYPDQ==
-
 fetch-blob@^3.1.2, fetch-blob@^3.1.4:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/fetch-blob/-/fetch-blob-3.2.0.tgz#f09b8d4bbd45adc6f0c20b7e787e793e309dcce9"
@@ -2441,18 +2436,7 @@ globalthis@^1.0.3:
     define-properties "^1.2.1"
     gopd "^1.0.1"
 
-globby@13.2.2:
-  version "13.2.2"
-  resolved "https://registry.yarnpkg.com/globby/-/globby-13.2.2.tgz#63b90b1bf68619c2135475cbd4e71e66aa090592"
-  integrity sha512-Y1zNGV+pzQdh7H39l9zgB4PJqjRNqydvdYCDG4HFXM4XuvSaQQlEc91IU1yALL8gUTDomgBAfz3XJdmUS+oo0w==
-  dependencies:
-    dir-glob "^3.0.1"
-    fast-glob "^3.3.0"
-    ignore "^5.2.4"
-    merge2 "^1.4.1"
-    slash "^4.0.0"
-
-globby@^11.1.0:
+globby@11.1.0, globby@^11.1.0:
   version "11.1.0"
   resolved "https://registry.yarnpkg.com/globby/-/globby-11.1.0.tgz#bd4be98bb042f83d796f7e3811991fbe82a0d34b"
   integrity sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==
@@ -2463,6 +2447,17 @@ globby@^11.1.0:
     ignore "^5.2.0"
     merge2 "^1.4.1"
     slash "^3.0.0"
+
+globby@13.2.2:
+  version "13.2.2"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-13.2.2.tgz#63b90b1bf68619c2135475cbd4e71e66aa090592"
+  integrity sha512-Y1zNGV+pzQdh7H39l9zgB4PJqjRNqydvdYCDG4HFXM4XuvSaQQlEc91IU1yALL8gUTDomgBAfz3XJdmUS+oo0w==
+  dependencies:
+    dir-glob "^3.0.1"
+    fast-glob "^3.3.0"
+    ignore "^5.2.4"
+    merge2 "^1.4.1"
+    slash "^4.0.0"
 
 gopd@^1.0.1:
   version "1.0.1"
@@ -4661,14 +4656,6 @@ text-table@^0.2.0:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
   integrity sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==
-
-tinyglobby@^0.2.9:
-  version "0.2.10"
-  resolved "https://registry.yarnpkg.com/tinyglobby/-/tinyglobby-0.2.10.tgz#e712cf2dc9b95a1f5c5bbd159720e15833977a0f"
-  integrity sha512-Zc+8eJlFMvgatPZTl6A9L/yht8QqdmUNtURHaKZLmKBE12hNPSrqNkUp2cs3M/UKmNVVAMFQYSjYIVHDjW5zew==
-  dependencies:
-    fdir "^6.4.2"
-    picomatch "^4.0.2"
 
 titleize@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
This pull request reverts the changes made in commit 99a26329cbe408fd08f2a53cd49cf4744573aaa9, which replaced the `globby` package with `tinyglobby`. The reason for reverting is to maintain compatibility with other dependencies that rely on `globby`.