### PR TITLE
test: add hybrid ESM test setup with libphonenumber-js

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,7 +412,7 @@ PKG_NODE_PATH=/path/to/node pkg app.js
 
 This error is tracked by issue [#16](https://github.com/yao-pkg/pkg/issues/16#issuecomment-1945486658). Follow the link in oder to find a workaround.
 
-In most cases adding `--option experimental-require-module` to `pkg` command line will solve the issue.
+In most cases adding `--options experimental-require-module` to `pkg` command line will solve the issue.
 
 ### Error: Cannot find module XXX (when using `child_process`)
 

--- a/README.md
+++ b/README.md
@@ -408,6 +408,12 @@ PKG_NODE_PATH=/path/to/node pkg app.js
 
 ## Troubleshooting
 
+### Error: Error [ERR_REQUIRE_ESM]: require() of ES Module
+
+This error is tracked by issue [#16](https://github.com/yao-pkg/pkg/issues/16#issuecomment-1945486658). Follow the link in oder to find a workaround.
+
+In most cases adding `--option experimental-require-module` to `pkg` command line will solve the issue.
+
 ### Error: Cannot find module XXX (when using `child_process`)
 
 When using `child_process` methods to run a new process pkg by default will invoke it using NodeJS runtime that is built into the executable. This means that if you are trying to spawn the packaged app itself you will get above error. In order to avoid this you must set `PKG_EXECPATH` env set to `""`:

--- a/test/test-01-hybrid-esm/main.js
+++ b/test/test-01-hybrid-esm/main.js
@@ -1,0 +1,59 @@
+#!/usr/bin/env node
+
+'use strict';
+
+const assert = require('assert');
+const utils = require('../utils.js');
+
+// sea is not supported on Node.js < 20
+if (utils.getNodeMajorVersion() < 10) {
+  return;
+}
+
+assert(__dirname === process.cwd());
+
+utils.exec.sync('npm install --no-package-lock --no-save', {
+  stdio: 'inherit',
+});
+
+const input = './test-hybrid.js';
+
+const newcomers = [
+  'test-hybrid-linux',
+  'test-hybrid-macos',
+  'test-hybrid-win.exe',
+];
+
+const before = utils.filesBefore(newcomers);
+
+utils.pkg.sync([input, '--options', 'experimental-require-module'], {
+  stdio: 'inherit',
+});
+
+console.log('pkg end');
+
+try {
+  console.log('test-hybrid-linux');
+  // try to spawn one file based on the platform
+  if (process.platform === 'linux') {
+    assert.equal(
+      utils.spawn.sync('./test-hybrid-linux', []),
+      '8005553535\n',
+      'Output matches',
+    );
+  } else if (process.platform === 'darwin') {
+    assert.equal(
+      utils.spawn.sync('./test-hybrid-macos', []),
+      '8005553535\n',
+      'Output matches',
+    );
+  } else if (process.platform === 'win32') {
+    assert.equal(
+      utils.spawn.sync('./test-hybrid-win.exe', []),
+      '8005553535\n',
+      'Output matches',
+    );
+  }
+} finally {
+  utils.filesAfter(before, newcomers);
+}

--- a/test/test-01-hybrid-esm/main.js
+++ b/test/test-01-hybrid-esm/main.js
@@ -6,7 +6,7 @@ const assert = require('assert');
 const utils = require('../utils.js');
 
 // sea is not supported on Node.js < 20
-if (utils.getNodeMajorVersion() < 18) {
+if (utils.getNodeMajorVersion() < 20) {
   return;
 }
 

--- a/test/test-01-hybrid-esm/main.js
+++ b/test/test-01-hybrid-esm/main.js
@@ -6,7 +6,7 @@ const assert = require('assert');
 const utils = require('../utils.js');
 
 // sea is not supported on Node.js < 20
-if (utils.getNodeMajorVersion() < 10) {
+if (utils.getNodeMajorVersion() < 18) {
   return;
 }
 

--- a/test/test-01-hybrid-esm/package.json
+++ b/test/test-01-hybrid-esm/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "test-01-hybrid-esm",
+  "version": "1.0.0",
+  "description": "",
+  "bin": "test-hybrid.js",
+  "keywords": [],
+  "author": "",
+  "license": "MIT",
+  "dependencies": {
+    "libphonenumber-js": "^1.11.20"
+  },
+  "pkg": {
+    "patches": {
+      "./node_modules/libphonenumber-js/package.json": [
+        "\"type\": \"module\",",
+        ""
+      ]
+    }
+  }
+}

--- a/test/test-01-hybrid-esm/test-hybrid.js
+++ b/test/test-01-hybrid-esm/test-hybrid.js
@@ -1,0 +1,13 @@
+'use strict';
+
+const { findPhoneNumbersInText } = require('libphonenumber-js');
+
+const res = findPhoneNumbersInText(
+  `
+    For tech support call +7 (800) 555-35-35 internationally
+    or reach a local US branch at (213) 373-4253 ext. 1234.
+  `,
+  'US',
+);
+
+console.log(res[0].number.nationalNumber);

--- a/test/utils.js
+++ b/test/utils.js
@@ -150,6 +150,7 @@ module.exports.pkg = function () {
 };
 
 const es5path = path.resolve(__dirname, '../lib-es5/bin.js');
+const tsPath = path.resolve(__dirname, '../lib/bin.ts');
 
 /**
  *
@@ -159,9 +160,15 @@ const es5path = path.resolve(__dirname, '../lib-es5/bin.js');
  */
 module.exports.pkg.sync = function (args, opts) {
   args = args.slice();
-  const es5 = existsSync(es5path);
-  args.unshift(es5path);
-  assert(es5, 'Run `yarn build` first!');
+
+  if (process.env.DEV === 'true') {
+    args.unshift(tsPath);
+    args.unshift('-r', 'esbuild-register');
+  } else {
+    const es5 = existsSync(es5path);
+    args.unshift(es5path);
+    assert(es5, 'Run `yarn build` first!');
+  }
 
   if (Array.isArray(opts)) opts = { stdio: opts };
 


### PR DESCRIPTION
Introduce a test setup for hybrid ESM using libphonenumber-js, addressing the ESM module loading issue. Include troubleshooting information for related errors.