### PR TITLE
feat: automatically create output directory with `--sea` option

### DIFF
--- a/lib/sea.ts
+++ b/lib/sea.ts
@@ -1,6 +1,6 @@
 import { exec as cExec } from 'child_process';
 import util from 'util';
-import path, { basename, dirname, join, resolve } from 'path';
+import { basename, dirname, join, resolve } from 'path';
 import { copyFile, writeFile, rm, mkdir, stat, readFile } from 'fs/promises';
 import { createWriteStream } from 'fs';
 import { pipeline } from 'stream/promises';
@@ -308,7 +308,7 @@ async function bake(
   );
 
   if (!(await exists(dirname(outPath)))) {
-    await mkdir(path.dirname(outPath), { recursive: true });
+    await mkdir(dirname(outPath), { recursive: true });
   }
   // check if executable_path exists
   if (await exists(outPath)) {


### PR DESCRIPTION
## Why

Fixes #180

## What

- Create the directory specified by the `--output` option when running with the `--sea` option.

NOTE: Since I wasn’t sure whether the existing behavior was a bug or intentional, I set the commit type to `feat`.
