### PR TITLE
feat: bump fetch with node 22.20.0, 22.22.0, and 24.13.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@babel/generator": "^7.23.0",
     "@babel/parser": "^7.23.0",
     "@babel/types": "^7.23.0",
-    "@yao-pkg/pkg-fetch": "3.5.31",
+    "@yao-pkg/pkg-fetch": "3.5.32",
     "into-stream": "^6.0.0",
     "minimist": "^1.2.6",
     "multistream": "^4.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -795,10 +795,10 @@
   resolved "https://registry.yarnpkg.com/@ungap/structured-clone/-/structured-clone-1.2.0.tgz#756641adb587851b5ccb3e095daf27ae581c8406"
   integrity sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==
 
-"@yao-pkg/pkg-fetch@3.5.31":
-  version "3.5.31"
-  resolved "https://registry.yarnpkg.com/@yao-pkg/pkg-fetch/-/pkg-fetch-3.5.31.tgz#3de51680fba52d19c4c776fd8ea45e2be6a5320b"
-  integrity sha512-qBLFfCXJECsxMlvwamhdWR65LWI7Cnb40dmI+1NIr1Nfk8Ddc8luZIJsRRZER9UrY13X1NJZSRORsqIPYDsJbw==
+"@yao-pkg/pkg-fetch@3.5.32":
+  version "3.5.32"
+  resolved "https://registry.yarnpkg.com/@yao-pkg/pkg-fetch/-/pkg-fetch-3.5.32.tgz#4d9cb77a2f5977a513ae7c6e19cfa94737d0f624"
+  integrity sha512-hS8zzze5VVyVAciZoNX4q3ZmCdn0gi34P2SElk4PFbzkA4LPs7qBJ3LhUKb4d4KGw1HVkFJJOMgGomH7cMqQ5Q==
   dependencies:
     https-proxy-agent "^5.0.0"
     node-fetch "^2.6.6"


### PR DESCRIPTION
Bump the version of `@yao-pkg/pkg-fetch` to 3.5.32 to ensure compatibility with Node versions 22.20.0, 22.22.0, and 24.13.0.