### PR TITLE
chore: remove downlevelIteration option from tsconfig.json

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,10 +7,10 @@
     "declarationMap": true,
     "sourceMap": true,
     "outDir": "lib-es5",
+    "rootDir": "./lib",
     "strict": true,
     "esModuleInterop": true,
     "incremental": true,
-    "downlevelIteration": true,
     "resolveJsonModule": true,
     "skipLibCheck": true
   },


### PR DESCRIPTION
Eliminate the `downlevelIteration` option in the TypeScript configuration to streamline the build process.