### PR TITLE
chore: add CLAUDE.md referencing shared copilot instructions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,33 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code when working with this repository.
+
+## Shared Instructions
+
+Project-level AI coding instructions are maintained in a single shared location:
+
+- **[`.github/copilot-instructions.md`](.github/copilot-instructions.md)** — the primary reference for project overview, architecture, development workflow, testing, coding standards, and contribution guidelines.
+
+Please read that file for full context before making changes.
+
+## Quick Reference
+
+```bash
+# Build (required before testing)
+npm run build
+
+# Lint and auto-fix
+npm run lint
+npm run fix
+
+# Run all tests
+npm test
+
+# Run tests for a specific Node.js version
+npm run test:20
+npm run test:22
+npm run test:24
+
+# Watch mode (rebuild on change)
+npm run start
+```


### PR DESCRIPTION
## Summary

- Adds a `CLAUDE.md` file that points to `.github/copilot-instructions.md` as the single source of truth for AI coding instructions
- Includes only a minimal quick-reference section with the most essential commands (`build`, `lint`, `fix`, `test`, `start`)
- Avoids duplicating any content already covered in the shared copilot instructions

This keeps AI agent guidance in one place so updates to `.github/copilot-instructions.md` automatically apply to all tools (Copilot, Claude Code, etc.) without drift.

## Test plan

- [x] Verify `CLAUDE.md` renders correctly on GitHub
- [x] Verify links to `.github/copilot-instructions.md` resolve properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)