### PR TITLE
fix: lazy PKG_NATIVE_CACHE_PATH eval + integrity check for cached .node files

### DIFF
--- a/prelude/bootstrap.js
+++ b/prelude/bootstrap.js
@@ -2187,7 +2187,10 @@ function payloadFileSync(pointer) {
   //   - Windows: C:\Users\John\.cache
   // Custom example: /opt/myapp/cache or C:\myapp\cache
   // Native addons will be extracted to: <PKG_NATIVE_CACHE_BASE>/pkg/<hash>
-  const PKG_NATIVE_CACHE_BASE =
+  //
+  // Note: We capture the initial value as the default, but re-read process.env inside
+  // process.dlopen so that runtime changes to PKG_NATIVE_CACHE_PATH take effect.
+  const PKG_NATIVE_CACHE_DEFAULT =
     process.env.PKG_NATIVE_CACHE_PATH || path.join(homedir(), '.cache');
 
   function revertMakingLong(f) {
@@ -2209,7 +2212,9 @@ function payloadFileSync(pointer) {
       // the hash is needed to be sure we reload the module in case it changes
       const hash = createHash('sha256').update(moduleContent).digest('hex');
 
-      const tmpFolder = path.join(PKG_NATIVE_CACHE_BASE, 'pkg', hash);
+      // Re-read PKG_NATIVE_CACHE_PATH at each call so runtime changes take effect
+      const cacheBase = process.env.PKG_NATIVE_CACHE_PATH || PKG_NATIVE_CACHE_DEFAULT;
+      const tmpFolder = path.join(cacheBase, 'pkg', hash);
 
       fs.mkdirSync(tmpFolder, { recursive: true });
 
@@ -2237,7 +2242,17 @@ function payloadFileSync(pointer) {
       } else {
         const tmpModulePath = path.join(tmpFolder, moduleBaseName);
 
-        if (!fs.existsSync(tmpModulePath)) {
+        if (fs.existsSync(tmpModulePath)) {
+          // Verify cached file integrity against snapshot content.
+          // The folder name encodes the expected hash, but the file inside could
+          // have been replaced (e.g. by a local user to inject malicious code).
+          const cachedContent = fs.readFileSync(tmpModulePath);
+          const cachedHash = createHash('sha256').update(cachedContent).digest('hex');
+          if (cachedHash !== hash) {
+            // Cached file was tampered with or corrupted — re-extract from snapshot
+            fs.copyFileSync(modulePath, tmpModulePath);
+          }
+        } else {
           fs.copyFileSync(modulePath, tmpModulePath);
         }
 


### PR DESCRIPTION
## Summary

Two improvements to native addon extraction in `process.dlopen` (`prelude/bootstrap.js`):

### 1. Lazy `PKG_NATIVE_CACHE_PATH` evaluation

**Problem:** `PKG_NATIVE_CACHE_PATH` is captured in a `const` inside the IIFE at bootstrap time (before any user code runs). Applications that need to set `process.env.PKG_NATIVE_CACHE_PATH` at runtime — for example, to redirect native addon extraction to a protected directory — cannot do so because the value is already frozen.

**Fix:** Re-read `process.env.PKG_NATIVE_CACHE_PATH` inside `process.dlopen` on each call, falling back to the value captured at startup. This is fully backward-compatible: if the env var is set before the process starts, behavior is unchanged. If set at runtime before the first native addon load, the new value takes effect.

### 2. SHA-256 integrity verification for cached `.node` files

**Problem:** The single-file code path (the `else` branch in `process.dlopen`) only checks `fs.existsSync` before loading a cached `.node` file. If a cached file has been replaced (e.g. by a local user placing a malicious `.node` in `~/.cache/pkg/`), it is loaded without any verification. This enables a **privilege escalation attack** when the packaged application runs at a higher privilege level than the user who controls the cache directory.

Note: The `node_modules` code path (`mIndex > 0`) already has hash verification via `copyFolderRecursiveSync`, so this only affects the single-file path.

**Fix:** Before loading a cached `.node` file, compute its SHA-256 hash and compare it against the expected hash (already computed from the snapshot content on line 2210). If they don't match, re-extract from the snapshot.

## Security context

Native addons are extracted by default to `~/.cache/pkg/`, a user-writable directory. When a pkg-packaged application runs with elevated privileges (e.g. as SYSTEM on Windows during installation), a standard user can pre-place a malicious `.node` file in the cache directory. The application then loads it at its elevated privilege level, granting the user arbitrary code execution as SYSTEM.

## Test plan

- [ ] Verify backward compatibility: set `PKG_NATIVE_CACHE_PATH` as OS env var before process start — extraction should use the specified path (unchanged behavior)
- [ ] Verify runtime override: set `process.env.PKG_NATIVE_CACHE_PATH` in application code before first native addon `require()` — extraction should use the new path
- [ ] Verify integrity check: replace a cached `.node` file with a different binary — application should re-extract from snapshot instead of loading the tampered file
- [ ] Verify no regression for `node_modules` path (mIndex > 0) — `copyFolderRecursiveSync` behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)