### PR TITLE
fix: add SHA-256 integrity check for cached .node files

### DIFF
--- a/prelude/bootstrap.js
+++ b/prelude/bootstrap.js
@@ -2237,7 +2237,17 @@ function payloadFileSync(pointer) {
       } else {
         const tmpModulePath = path.join(tmpFolder, moduleBaseName);
 
-        if (!fs.existsSync(tmpModulePath)) {
+        if (fs.existsSync(tmpModulePath)) {
+          // Verify cached file integrity against snapshot content.
+          // The folder name encodes the expected hash, but the file inside could
+          // have been replaced (e.g. by a local user to inject malicious code).
+          const cachedContent = fs.readFileSync(tmpModulePath);
+          const cachedHash = createHash('sha256').update(cachedContent).digest('hex');
+          if (cachedHash !== hash) {
+            // Cached file was tampered with or corrupted — re-extract from snapshot
+            fs.copyFileSync(modulePath, tmpModulePath);
+          }
+        } else {
           fs.copyFileSync(modulePath, tmpModulePath);
         }
 


### PR DESCRIPTION
## Summary

- Adds SHA-256 integrity verification for cached `.node` files in the single-file code path of `process.dlopen`
- The `node_modules` path already had hash verification via `copyFolderRecursiveSync`, but the single-file path only checked `fs.existsSync` — a tampered or corrupted cached file was silently loaded
- A mismatched file is now detected and re-extracted from the snapshot

## Security context

Native addons are extracted to user-writable directories (e.g. `~/.cache/pkg/`). Without integrity verification, an attacker could replace a cached `.node` file with a malicious one that executes at the privilege level of the packaged application. This closes that privilege escalation vector.

## Relation to #228

This is the integrity-check-only portion of #228, split per reviewer feedback. The lazy `PKG_NATIVE_CACHE_PATH` eval has been dropped from this PR.

## Test plan

- [x] Verify diff only touches the single-file `else` branch in `process.dlopen`
- [x] Package an app with a native addon, tamper with the cached `.node` file, confirm it gets re-extracted
- [x] Package an app with a native addon, leave cache intact, confirm it loads without re-extraction

🤖 Generated with [Claude Code](https://claude.com/claude-code)