### PR TITLE
fix: set-once-freeze for PKG_NATIVE_CACHE_PATH resolution

### DIFF
--- a/prelude/bootstrap.js
+++ b/prelude/bootstrap.js
@@ -2187,8 +2187,22 @@ function payloadFileSync(pointer) {
   //   - Windows: C:\Users\John\.cache
   // Custom example: /opt/myapp/cache or C:\myapp\cache
   // Native addons will be extracted to: <PKG_NATIVE_CACHE_BASE>/pkg/<hash>
-  const PKG_NATIVE_CACHE_BASE =
+  //
+  // The cache path is resolved lazily on the first dlopen call and then frozen.
+  // This gives the application a window to set process.env.PKG_NATIVE_CACHE_PATH
+  // in its init code (before any native addon is loaded) without requiring it to
+  // be set before the process starts. Once resolved, the value cannot change.
+  const PKG_NATIVE_CACHE_DEFAULT =
     process.env.PKG_NATIVE_CACHE_PATH || path.join(homedir(), '.cache');
+  let PKG_NATIVE_CACHE_BASE = null;
+
+  function getNativeCacheBase() {
+    if (PKG_NATIVE_CACHE_BASE === null) {
+      PKG_NATIVE_CACHE_BASE =
+        process.env.PKG_NATIVE_CACHE_PATH || PKG_NATIVE_CACHE_DEFAULT;
+    }
+    return PKG_NATIVE_CACHE_BASE;
+  }
 
   function revertMakingLong(f) {
     if (/^\\\\\?\\/.test(f)) return f.slice(4);
@@ -2209,7 +2223,7 @@ function payloadFileSync(pointer) {
       // the hash is needed to be sure we reload the module in case it changes
       const hash = createHash('sha256').update(moduleContent).digest('hex');
 
-      const tmpFolder = path.join(PKG_NATIVE_CACHE_BASE, 'pkg', hash);
+      const tmpFolder = path.join(getNativeCacheBase(), 'pkg', hash);
 
       fs.mkdirSync(tmpFolder, { recursive: true });
 


### PR DESCRIPTION
## Problem

`PKG_NATIVE_CACHE_PATH` is captured once in the bootstrap IIFE, before any application code runs. This means a packaged app cannot programmatically redirect its native addon cache at startup — the only way to set the path is via the process environment before launch.

This is a problem for apps that need to determine the cache path at runtime (e.g. based on install location) and for security-sensitive apps that must ensure the cache points to a protected directory regardless of what environment variables a user has set.

## Solution

Defer resolution of `PKG_NATIVE_CACHE_PATH` to the first `dlopen` call, then freeze it. This gives the application's entry point a window to set `process.env.PKG_NATIVE_CACHE_PATH` before any native addon is loaded, after which the value is locked.

Existing behavior (env var set before process starts) is unchanged.

## Relation to #228

This is the set-once-freeze portion of #228, split per reviewer feedback. The SHA-256 integrity check is in a separate PR (#230).

## Test plan

- [x] Package an app that sets `PKG_NATIVE_CACHE_PATH` in its entry point before loading native addons — verify the runtime value is used
- [x] Package an app with `PKG_NATIVE_CACHE_PATH` pre-set in the environment — verify it works as before
- [x] Package an app without `PKG_NATIVE_CACHE_PATH` set — verify default `~/.cache` fallback works
- [x] Verify that changing `PKG_NATIVE_CACHE_PATH` after the first native addon load has no effect