### PR TITLE
fix(docs): repair migration link and mermaid label clipping

### DIFF
--- a/docs-site/.vitepress/config.ts
+++ b/docs-site/.vitepress/config.ts
@@ -146,6 +146,16 @@ export default withMermaid({
   mermaid: {
     // theme intentionally unset — vitepress-plugin-mermaid auto-switches
     // between 'default' (light) and 'dark' based on VitePress appearance
+    themeVariables: {
+      // keep in sync with the font-size override in custom.css so mermaid's
+      // node-size measurements match the rendered text and labels don't clip
+      fontSize: '15px',
+    },
+    flowchart: {
+      htmlLabels: true,
+      useMaxWidth: true,
+      padding: 12,
+    },
   },
   mermaidPlugin: {
     class: 'mermaid-diagram',

--- a/docs-site/.vitepress/theme/custom.css
+++ b/docs-site/.vitepress/theme/custom.css
@@ -97,6 +97,19 @@
   font-size: 15px !important;
 }
 
+/* mermaid renders label text through a markdown parser that wraps lines in
+   <p> elements. The browser's default <p> margin inflates the rendered
+   label height beyond the foreignObject size mermaid measured, so the last
+   line gets clipped below the node rect. Zero the margin so rendered and
+   measured heights match. */
+.mermaid-diagram svg .nodeLabel p,
+.mermaid-diagram svg .edgeLabel p,
+.mermaid-diagram svg .cluster-label p,
+.mermaid-diagram svg .label p {
+  margin: 0 !important;
+  line-height: 1.5 !important;
+}
+
 /* dark mode: force readable label colors — mermaid's dark theme
    sometimes leaves inherited fills that blend into the background */
 .dark .mermaid-diagram svg .nodeLabel,

--- a/docs-site/index.md
+++ b/docs-site/index.md
@@ -43,7 +43,9 @@ features:
 ---
 
 <div class="fork-banner">
-<strong>Looking for <code>vercel/pkg</code>?</strong> This is <a href="https://github.com/yao-pkg/pkg"><code>yao-pkg/pkg</code></a> — the actively maintained fork. The original <code>vercel/pkg</code> is archived. <code>@yao-pkg/pkg</code> is a drop-in replacement — rename the dep and keep shipping. See the [migration guide](/guide/migration).
+
+**Looking for `vercel/pkg`?** This is [`yao-pkg/pkg`](https://github.com/yao-pkg/pkg) — the actively maintained fork. The original `vercel/pkg` is archived. `@yao-pkg/pkg` is a drop-in replacement — rename the dep and keep shipping. See the [migration guide](/guide/migration).
+
 </div>
 
 <div class="landing-badges">


### PR DESCRIPTION
## Summary

- **Broken link on landing page** — `docs-site/index.md`: the `[migration guide](/guide/migration)` link inside `<div class="fork-banner">` was rendered as literal text because raw HTML blocks don't parse inline markdown without blank-line separation. The div now wraps blank-line-separated markdown content so the link resolves to `/pkg/guide/migration`.
- **Mermaid label clipping** — in every multi-line node label, the last line was cut off below the node rect (e.g. `User code / fs.readFileSync / /snapshot/app/x.js`, `Executable with / custom VFS`, `Traditional / walker + bytecode`). Mermaid renders label text through a markdown parser that wraps lines in `<p>` tags; the browser's default `<p>` margin inflated the rendered label height beyond the `foreignObject` height mermaid had pre-measured. Added CSS to zero `<p>` margins inside `.nodeLabel / .edgeLabel / .cluster-label / .label` and normalized `line-height`.
- **Mermaid font alignment** — `.vitepress/config.ts`: set `themeVariables.fontSize: '15px'` and `flowchart.padding: 12` so mermaid's layout math matches the 15px font-size applied by `custom.css`.

## Test plan

- [x] `npx vitepress build` succeeds with no dead-link errors
- [x] Verified in preview that the landing page renders the migration link as a proper anchor
- [x] Verified that all mermaid diagrams on `/pkg/architecture` render every label line inside its node box with no bottom clipping — both 2-line and 3-line labels
- [x] Pre-commit hook (lint-staged + prettier) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)