### PR TITLE
fix(sea): prevent sentinel duplication when pkg is in dependencies

### DIFF
--- a/.claude/skills/pkg-debug/SKILL.md
+++ b/.claude/skills/pkg-debug/SKILL.md
@@ -1,0 +1,342 @@
+---
+name: pkg-debug
+description: >
+  Debug and troubleshoot @yao-pkg/pkg packaging issues — build failures,
+  runtime crashes, missing assets, bloated binaries, native addon errors,
+  cross-compile regressions, SEA sentinel problems, and patches/dictionaries.
+when_to_use: >
+  "debug pkg", "pkg not working", "packaged binary crashes", "missing file
+  in binary", "binary too large", "cross-compile broken", "native addon
+  fails", "SEA error", "Multiple occurences of sentinel", "ERR_REQUIRE_ESM",
+  "Cannot find module" in pkg context, "Cannot execute binary from snapshot"
+user-invocable: true
+disable-model-invocation: false
+argument-hint: [description of the issue]
+allowed-tools: Read Bash Grep Glob Agent
+effort: high
+---
+
+# pkg Debugging & Troubleshooting
+
+Diagnose and fix issues when packaging Node.js apps with `@yao-pkg/pkg`.
+
+**User's issue:** $ARGUMENTS
+
+**Official docs:** <https://yao-pkg.github.io/pkg/>
+
+For the full pkg configuration schema, patches examples, dictionary format,
+and contributing guide, see [reference.md](reference.md).
+
+## Triage — Start here
+
+Identify the failure stage:
+
+| Stage             | Symptom                                           | Jump to                                      |
+| ----------------- | ------------------------------------------------- | -------------------------------------------- |
+| **Build**         | `pkg` exits with error before producing a binary  | [Build failures](#build-failures)            |
+| **Runtime**       | Binary produced but crashes/errors on launch      | [Runtime errors](#runtime-errors)            |
+| **Missing files** | App runs but can't find assets/modules at runtime | [Missing assets](#missing-assets-or-modules) |
+| **Binary size**   | Binary is unexpectedly large                      | [Binary bloat](#binary-bloat)                |
+| **Cross-compile** | Build OK on host but binary broken on target      | [Cross-compile](#cross-compile-issues)       |
+| **Native addons** | `.node` files fail to load                        | [Native addons](#native-addon-issues)        |
+| **SEA-specific**  | Enhanced SEA sentinel/blob/fuse errors            | [SEA issues](#sea-specific-issues)           |
+
+## Diagnostic tools
+
+### CLI flags
+
+```bash
+pkg --debug app.js -o dist/app      # Inject diagnostic prelude (build-time)
+pkg . --sea                          # Enhanced SEA (stock Node.js, no bytecode)
+pkg . --no-bytecode                  # Standard mode without V8 bytecode
+pkg . --options max-old-space-size=4096  # Bake Node.js flags into binary
+```
+
+### Runtime environment variables
+
+These work **inside the packaged binary**, not at build time.
+
+| Variable                | Values | Purpose                                                                     |
+| ----------------------- | ------ | --------------------------------------------------------------------------- |
+| `DEBUG_PKG`             | `1`    | Dump VFS tree + symlink table at startup (needs `--debug` build)            |
+| `DEBUG_PKG`             | `2`    | Above + trace every `fs` call (readFile, stat, readdir, ...)                |
+| `DEBUG_PKG_PERF`        | `1`    | Startup performance report (SEA only, works without `--debug`)              |
+| `SIZE_LIMIT_PKG`        | bytes  | With `DEBUG_PKG`, only show files larger than N (default 5 MB)              |
+| `FOLDER_LIMIT_PKG`      | bytes  | With `DEBUG_PKG`, only show folders larger than N (default 10 MB)           |
+| `PKG_NATIVE_CACHE_PATH` | path   | Override native addon extraction directory (default `~/.cache/pkg-native/`) |
+
+### Standard diagnostic workflow
+
+```bash
+# 1. Build with diagnostic prelude
+pkg --debug . -o dist/app
+
+# 2. List everything in the VFS
+DEBUG_PKG=1 ./dist/app
+
+# 3. Search for a specific file
+DEBUG_PKG=1 ./dist/app 2>&1 | grep "myfile.json"
+
+# 4. Trace all fs calls at runtime
+DEBUG_PKG=2 ./dist/app
+
+# 5. SEA startup profiling (no --debug needed)
+DEBUG_PKG_PERF=1 ./dist/app
+```
+
+---
+
+## Build failures
+
+### `ERR_REQUIRE_ESM`
+
+ESM module loaded via `require()`.
+
+```bash
+pkg app.js --options experimental-require-module
+```
+
+Not needed on Node >= 22.12.0 (flag is default).
+See: <https://yao-pkg.github.io/pkg/guide/troubleshooting#error-err-require-esm>
+
+### `Multiple occurences of sentinel` (SEA)
+
+`@yao-pkg/pkg` is in the project's `dependencies` — the walker bundles it
+into the SEA archive and the sentinel string causes postject to fail.
+
+**Fix:** move `@yao-pkg/pkg` to `devDependencies`, or upgrade to pkg >= 6.16.0.
+
+### Bytecode compilation fails for cross-arch
+
+Node 22 V8 bytecode is architecture-specific.
+
+```bash
+# Option 1: Use SEA (no bytecode step)
+pkg . --sea -t node22-linux-arm64
+
+# Option 2: Skip bytecode
+pkg . --no-bytecode --public-packages '*' --public -t node22-linux-arm64
+
+# Option 3: Target Node 24 (regression fixed)
+pkg . -t node24-linux-arm64
+```
+
+---
+
+## Runtime errors
+
+### `Cannot find module XXX` (child_process)
+
+Child process re-enters the packaged binary. Unset `PKG_EXECPATH`:
+
+```js
+spawn(process.execPath, [...], {
+  env: { ...process.env, PKG_EXECPATH: '' }
+});
+```
+
+See: <https://yao-pkg.github.io/pkg/guide/troubleshooting#error-cannot-find-module-xxx-when-using-child-process>
+
+### `Cannot execute binary from snapshot`
+
+OS can't exec binaries from VFS. Extract to disk first:
+
+```js
+if (process.pkg) {
+  const { pipeline } = require('stream/promises');
+  const file = fs.createWriteStream('ffmpeg');
+  await pipeline(fs.createReadStream('/snapshot/path/ffmpeg'), file);
+  fs.chmodSync('ffmpeg', 0o755);
+}
+```
+
+`.node` native addons are auto-extracted. Other binaries must be extracted manually.
+See: <https://yao-pkg.github.io/pkg/guide/troubleshooting#error-cannot-execute-binary-from-snapshot>
+
+### `ERR_INSPECTOR_NOT_AVAILABLE` / `internalModuleStat is not a function`
+
+`NODE_OPTIONS` leaking from IDE/shell. Clear them:
+
+```bash
+unset NODE_OPTIONS NODE_DEBUG NODE_EXTRA_CA_CERTS NODE_NO_WARNINGS
+./app
+```
+
+See: <https://yao-pkg.github.io/pkg/guide/troubleshooting#error-err-inspector-not-available>
+
+---
+
+## Missing assets or modules
+
+### Why files go missing
+
+1. **Dynamic `require(variable)`** — walker can't statically resolve it
+2. **Non-JS assets** (templates, JSON, images) — not followed by walker
+3. **`path.join` with variable** — `path.join(__dirname, var)` not detected
+
+### Auto-detection rules
+
+`pkg` auto-detects `path.join(__dirname, 'literal.ext')` **only when:**
+
+- Exactly 2 arguments
+- Second argument is a **string literal** (not a variable, not a template with expressions)
+
+See: <https://yao-pkg.github.io/pkg/guide/detecting-assets>
+
+### Manual configuration (package.json)
+
+```json
+{
+  "pkg": {
+    "scripts": ["build/**/*.js"],
+    "assets": ["views/**/*", "templates/**/*.html", "config/*.json"]
+  }
+}
+```
+
+- **`scripts`** — JS files compiled to V8 bytecode (source stripped).
+- **`assets`** — raw files embedded as-is, accessible under `/snapshot/`.
+
+### Verification
+
+```bash
+pkg --debug . -o dist/app
+DEBUG_PKG=1 ./dist/app 2>&1 | grep "expected-file"
+```
+
+If the file is missing, add it to `assets`. If it's a JS file loaded dynamically, add to `scripts`.
+
+---
+
+## Binary bloat
+
+### Diagnose
+
+```bash
+pkg --debug . -o dist/app
+SIZE_LIMIT_PKG=500000 FOLDER_LIMIT_PKG=2000000 DEBUG_PKG=1 ./dist/app
+```
+
+### Fix with `ignore`
+
+```json
+{
+  "pkg": {
+    "ignore": [
+      "**/*/node_modules/*/test/**",
+      "**/*/node_modules/*/docs/**",
+      "**/*/node_modules/*/.github/**"
+    ]
+  }
+}
+```
+
+Note: `**` and `*` do NOT match dotfiles — spell `.github` explicitly.
+
+### Consider SEA with bundler
+
+Pre-bundle with esbuild/webpack, then `pkg --sea bundle.js`. This produces
+the smallest SEA binaries because only reachable code is included.
+
+See: <https://yao-pkg.github.io/pkg/guide/advanced-debug-vfs>
+
+---
+
+## Cross-compile issues
+
+### Node 22 Standard mode regression
+
+Standard cross-compile is **broken on Node 22**:
+
+- `linux-arm64` → runtime crash `Error: UNEXPECTED-20` ([#181](https://github.com/yao-pkg/pkg/issues/181))
+- `win-x64` → silent exit code 4, no output ([#87](https://github.com/yao-pkg/pkg/issues/87))
+
+**Workarounds:** (any one)
+
+1. `pkg . --sea` (Enhanced SEA — works out of the box)
+2. `pkg . --no-bytecode --public-packages '*' --public` (skip bytecode)
+3. Target Node 20 or Node 24 (regression is Node-22-specific)
+
+### Cross-platform SEA builds
+
+SEA cross-compile works when host major == target major. When they differ,
+pkg must execute the downloaded target binary to generate the blob — this
+fails for cross-platform builds (Linux host can't run macOS binary).
+
+**Rule:** match host Node major to target Node major. Use `nvm use <major>`
+before running `pkg`.
+
+---
+
+## Native addon issues
+
+Native `.node` files are auto-extracted to `~/.cache/pkg-native/<sha256>/`.
+
+### Common problems
+
+- **`linuxstatic` target** cannot load native addons — use `linux` target
+- **Arch mismatch** — `.node` must be compiled for **target** arch
+- **Cache deleted** — antivirus may clean cache dir. Set `PKG_NATIVE_CACHE_PATH`
+- **Missing `.node` file** — add to `assets`: `"node_modules/pkg/prebuilds/**/*.node"`
+
+See: <https://yao-pkg.github.io/pkg/guide/native-addons>
+
+---
+
+## SEA-specific issues
+
+### Mode selection
+
+| Input                             | Mode                                         |
+| --------------------------------- | -------------------------------------------- |
+| `pkg app.js --sea`                | Simple SEA (single bundled file)             |
+| `pkg . --sea` (with package.json) | Enhanced SEA (full walker + VFS)             |
+| `pkg .` (no `--sea`)              | Standard mode (V8 bytecode, patched Node.js) |
+
+### `DEBUG_PKG_PERF=1` output interpretation
+
+```
+[pkg:perf] manifest parse       14.0ms    ← JSON parsing overhead
+[pkg:perf] archive load          1.2ms    ← Raw binary load
+[pkg:perf] vfs mount + hooks     3.3ms    ← fs patching
+[pkg:perf] module loading      730.1ms    ← require() chain
+```
+
+High `module loading` → too many files; consider pre-bundling with esbuild.
+
+### Worker threads in SEA
+
+SEA auto-patches the `Worker` constructor for `/snapshot/` paths. If a worker
+fails to find its module, verify with `DEBUG_PKG=1` that the file is in the VFS.
+
+See: <https://yao-pkg.github.io/pkg/guide/sea-mode>
+
+---
+
+## Patches and dictionaries
+
+When a dependency uses code patterns that don't work in packaged apps (e.g.
+`require('inspector')`, hardcoded paths, dynamic imports), use `patches` in
+your `package.json` `pkg` config. `pkg` also ships built-in `dictionary/`
+entries for known packages that are applied automatically.
+
+For the full patches format, real-world examples, monorepo path conventions,
+dictionary file structure, and contributing guide, see [reference.md](reference.md).
+
+---
+
+## Quick checklist
+
+When a user reports any pkg issue, run through this:
+
+1. **What mode?** Standard or SEA? (`--sea` flag or `pkg.sea: true`)
+2. **What Node version?** Host and target (`node --version`, target triple)
+3. **Build or runtime failure?** Does `pkg` succeed? Does the binary run?
+4. **`DEBUG_PKG=1`** — is the expected file in the VFS?
+5. **`NODE_OPTIONS` clean?** — `printenv | grep NODE`
+6. **Stale cache?** — `rm -rf ~/.pkg-cache && pkg ...`
+7. **Patches needed?** — check if the failing module uses `inspector`,
+   dynamic imports, or hardcoded paths → see [reference.md](reference.md)
+8. **Native addons?** — verify `.node` files match target arch
+9. **Cross-compile?** — Node 22 Standard mode is broken; use SEA or Node 24
+10. **Bug in pkg itself?** — see [contributing guide](reference.md#contributing-fixes-back-to-pkg)

--- a/.claude/skills/pkg-debug/reference.md
+++ b/.claude/skills/pkg-debug/reference.md
@@ -1,0 +1,173 @@
+# pkg Configuration & Patches Reference
+
+Supporting reference for the `/pkg-debug` skill.
+
+## Full pkg configuration schema
+
+```json
+{
+  "pkg": {
+    "scripts": ["build/**/*.js"],
+    "assets": ["views/**/*", "public/**/*"],
+    "ignore": ["**/*/node_modules/*/test/**"],
+    "targets": ["node22-linux-x64", "node22-macos-arm64", "node22-win-x64"],
+    "outputPath": "dist",
+    "patches": { "node_modules/foo/bar.js": ["old", "new"] },
+    "sea": true,
+    "seaConfig": {
+      "useCodeCache": false,
+      "disableExperimentalSEAWarning": true
+    },
+    "deployAssets": false
+  }
+}
+```
+
+| Key            | Type             | Purpose                                         |
+| -------------- | ---------------- | ----------------------------------------------- |
+| `scripts`      | glob \| string[] | JS compiled to V8 bytecode, source stripped     |
+| `assets`       | glob \| string[] | Raw files embedded in VFS under `/snapshot/`    |
+| `ignore`       | string[]         | Globs excluded from the binary                  |
+| `targets`      | string[]         | Target triples (`node<ver>-<os>-<arch>`)        |
+| `outputPath`   | string           | Output directory (equiv. to CLI `--out-path`)   |
+| `patches`      | object           | String replacements applied at walk time        |
+| `sea`          | boolean          | Opt into SEA mode without CLI `--sea`           |
+| `seaConfig`    | object           | Forwarded to Node.js SEA config                 |
+| `deployAssets` | boolean          | Copy assets next to binary instead of embedding |
+
+See: <https://yao-pkg.github.io/pkg/guide/configuration>
+
+---
+
+## Patches in package.json
+
+### Format
+
+```json
+{
+  "pkg": {
+    "patches": {
+      "file-path": ["search1", "replace1", "search2", "replace2"]
+    }
+  }
+}
+```
+
+The walker applies these string replacements when adding the file to the
+archive. The original file on disk is not modified.
+
+### Real-world examples
+
+```json
+{
+  "pkg": {
+    "patches": {
+      "node_modules/@sentry/node/cjs/anr/index.js": [
+        "const inspector = require('inspector');",
+        "const inspector = { open: () => {}, url: () => 'fake-pkg-url' };"
+      ],
+      "node_modules/rtsp-relay/index.js": [
+        "(require('ffmpeg-static'))",
+        "'/usr/bin/ffmpeg'"
+      ],
+      "node_modules/thread-stream/lib/worker.js": [
+        "worker = (await realImport(filename))",
+        "worker = realRequire(decodeURIComponent(filename.replace(process.platform === 'win32' ? 'file:///' : 'file://', '')))"
+      ],
+      "node_modules/pino/lib/transport-stream.js": [
+        "fn = (await realImport(toLoad))",
+        "fn = realRequire(target)"
+      ],
+      "node_modules/fontkit/dist/main.cjs": [
+        "new TextDecoder('ascii');",
+        "new TextDecoder('utf-8');"
+      ]
+    }
+  }
+}
+```
+
+### Monorepo / npm workspaces
+
+Paths are relative to the package.json that contains the `pkg` config. In a
+workspace layout where `node_modules` is hoisted to the root, use relative
+paths accordingly:
+
+```json
+{
+  "pkg": {
+    "patches": {
+      "../../node_modules/@sentry/node/cjs/anr/index.js": [
+        "const inspector = require('inspector');",
+        "const inspector = { open: () => {}, url: () => 'fake-pkg-url' };"
+      ]
+    },
+    "scripts": ["dist/**/*.js", "../../node_modules/pino/lib/worker.js"],
+    "assets": [
+      "../../node_modules/@img/**",
+      "../../node_modules/pdfkit/js/data/**"
+    ]
+  }
+}
+```
+
+---
+
+## Built-in dictionaries
+
+`pkg` ships with a `dictionary/` folder containing pre-configured patches for
+known npm packages. These are applied automatically — no user config needed.
+
+### Dictionary file format
+
+```javascript
+'use strict';
+
+module.exports = {
+  pkg: {
+    scripts: ['lib/types/*.js'], // compiled to bytecode
+    patches: {
+      // string replacements
+      'lib/index.js': [
+        'path.join(__dirname, "..")',
+        'path.dirname(process.execPath)',
+      ],
+    },
+    deployFiles: [
+      // extracted next to binary
+      ['prebuilds', 'zeromq/prebuilds', 'directory'],
+    ],
+  },
+};
+```
+
+### Check existing dictionaries
+
+```bash
+ls dictionary/ | grep <package-name>
+```
+
+If a package needs special handling but has no dictionary:
+
+1. Add patches to your `package.json` `pkg.patches` (project-local fix)
+2. Contribute a dictionary file to `yao-pkg/pkg` (helps all users)
+
+---
+
+## Contributing fixes back to pkg
+
+When debugging reveals a bug in pkg itself (not in the user's project):
+
+1. **Reproduce** — create a minimal test case that triggers the issue
+2. **Locate the root cause** in `lib/` (TypeScript source, compiled via `yarn build`)
+3. **Fix and test** — run the relevant tests:
+   ```bash
+   FLAVOR=test-XX-name node test/test.js node22 no-npm
+   ```
+4. **Lint** — `yarn fix` before committing
+5. **Open a PR** against `yao-pkg/pkg` (never `vercel/pkg` — it is archived)
+6. Use conventional commits: `fix:`, `feat:`, `refactor:`, etc.
+
+If the fix involves a missing dictionary entry for an npm package, add a file
+to `dictionary/<package-name>.js` following the format above (see
+`dictionary/zeromq.js` for a complete real-world example).

--- a/docs-site/guide/advanced-debug-vfs.md
+++ b/docs-site/guide/advanced-debug-vfs.md
@@ -70,3 +70,4 @@ Debug builds are slower, larger, and print sensitive internal paths at launch. T
 - [Output & debug](/guide/output)
 - [Environment variables](/guide/environment)
 - [Configuration → ignore](/guide/configuration#ignore-files)
+- [Claude Code `/pkg-debug` skill](/guide/troubleshooting#ai-assisted-debugging-with-claude-code) — interactive AI-assisted troubleshooting

--- a/docs-site/guide/troubleshooting.md
+++ b/docs-site/guide/troubleshooting.md
@@ -117,6 +117,37 @@ unset NODE_OPTIONS NODE_DEBUG NODE_EXTRA_CA_CERTS NODE_NO_WARNINGS
 
 If your shell or IDE re-adds them automatically, add an exception rule — e.g. in VS Code add `"terminal.integrated.env.linux": { "NODE_OPTIONS": null }` to disable the auto-injection just for this project.
 
+## AI-assisted debugging with Claude Code
+
+If you use [Claude Code](https://docs.anthropic.com/en/docs/claude-code), you can install the `/pkg-debug` skill to get interactive AI-assisted troubleshooting for any packaging issue.
+
+### Install the skill
+
+Download the skill file into your project's `.claude/skills/` directory:
+
+```bash
+mkdir -p .claude/skills/pkg-debug
+curl -fsSL https://raw.githubusercontent.com/yao-pkg/pkg/main/.claude/skills/pkg-debug/SKILL.md \
+  -o .claude/skills/pkg-debug/SKILL.md
+```
+
+::: tip Already cloned the repo?
+If you're working inside a clone of `yao-pkg/pkg`, the skill is already available — no extra setup needed.
+:::
+
+### Use it
+
+Start a new Claude Code session (skills are loaded at session start), then invoke it with a description of your issue:
+
+```
+/pkg-debug my binary crashes with "Cannot find module X"
+/pkg-debug binary is 500 MB, how do I reduce size?
+/pkg-debug cross-compile from linux to macos not working
+/pkg-debug native addon fails to load after packaging
+```
+
+The skill covers build failures, runtime crashes, missing assets, binary bloat, cross-compile regressions, native addons, SEA issues, and the `patches` / `dictionary` systems — all linked back to these docs.
+
 ## Still stuck?
 
 - Search existing issues: [github.com/yao-pkg/pkg/issues](https://github.com/yao-pkg/pkg/issues)

--- a/lib/sea.ts
+++ b/lib/sea.ts
@@ -31,6 +31,19 @@ import { inject as postjectInject } from 'postject';
 
 const execFileAsync = util.promisify(cExecFile);
 
+/**
+ * The SEA fuse sentinel that postject uses to activate the binary.
+ *
+ * Built by concatenation so the literal never appears as a single string
+ * in compiled output.  When pkg's own code is walked into a SEA archive
+ * (e.g. user lists @yao-pkg/pkg in dependencies), a verbatim sentinel
+ * would end up inside the injected blob, causing postject to find
+ * duplicate occurrences and fail with "Multiple occurences of sentinel".
+ */
+// prettier-ignore
+const SEA_SENTINEL_FUSE =
+  'NODE_SEA' + '_FUSE_fce680ab2cc467b6e072b8b5df1996b2';
+
 /** Returns stat of path when exits, false otherwise */
 const exists = async (path: string) => {
   try {
@@ -344,7 +357,7 @@ async function bake(
   // 1. "Text file busy" race condition from concurrent npx invocations
   // 2. "Argument is not a constructor" from npx downloading incompatible versions
   await postjectInject(outPath, 'NODE_SEA_BLOB', blobData, {
-    sentinelFuse: 'NODE_SEA_FUSE_fce680ab2cc467b6e072b8b5df1996b2',
+    sentinelFuse: SEA_SENTINEL_FUSE,
     machoSegmentName: target.platform === 'macos' ? 'NODE_SEA' : undefined,
     overwrite: true,
   });


### PR DESCRIPTION
## Summary

- **Fix:** When a user lists `@yao-pkg/pkg` in `dependencies` (instead of `devDependencies`), the walker includes `sea.js` in the SEA archive. The verbatim sentinel string `NODE_SEA_FUSE_fce680ab2cc467b6e072b8b5df1996b2` ends up inside the injected blob, causing postject to find it twice and fail with *"Multiple occurences of sentinel found in the binary"*. Fixed by splitting the sentinel via string concatenation so the literal never appears in compiled output.
- **Skill:** Add `/pkg-debug` Claude Code skill for interactive troubleshooting — covers build failures, runtime crashes, missing assets, binary bloat, cross-compile, native addons, SEA issues, patches/dictionaries, and contributing fixes back to pkg.
- **Docs:** Add Claude Code skill install/usage instructions to the troubleshooting page + cross-reference from the debug VFS page.

Repro: https://github.com/julianpoemp/yao-pkg-nestjs-sea-example

## Test plan

- [x] All 7 SEA tests pass (`test-00-sea`, `test-85` through `test-92`)
- [x] Verified `grep -c` shows 0 occurrences of the sentinel literal in compiled `lib-es5/sea.js`
- [x] Reproduced the bug with the NestJS example repo (3-target build fails before fix)
- [x] Verified the fix: 3-target build succeeds, Linux binary boots NestJS correctly
- [x] `yarn lint` passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)