### PR TITLE
feat(api): typed options object for exec()

### DIFF
--- a/docs-site/guide/api.md
+++ b/docs-site/guide/api.md
@@ -27,19 +27,56 @@ import { exec } from '@yao-pkg/pkg';
 
 :::
 
-## `exec(args)`
+## `exec()`
 
-`exec(args)` takes an array of command-line arguments and returns a `Promise<void>` that resolves when the build is complete, or rejects on failure.
+`exec()` accepts either a CLI-style argv array **or** a typed options object, and returns a `Promise<void>` that resolves when the build is complete, or rejects on failure.
+
+### Options object (recommended)
+
+```ts
+import { exec, PkgExecOptions } from '@yao-pkg/pkg';
+
+await exec({
+  input: 'index.js',
+  targets: ['node22-linux-x64'],
+  output: 'dist/app',
+  compress: 'Brotli',
+});
+```
+
+Only `input` is required. Everything else mirrors the CLI flags — see the [full field list](#pkgexecoptions-fields) below.
+
+### Argv array
 
 ```js
 const { exec } = require('@yao-pkg/pkg');
 
 await exec(['index.js', '--target', 'host', '--output', 'dist/app']);
-
-// do something with dist/app, upload, deploy, etc.
 ```
 
-The array elements are exactly the strings you'd pass on the command line — see [Getting started → CLI reference](/guide/getting-started#cli-reference) for the full option list.
+The strings are exactly what you'd pass on the command line — see [Getting started → CLI reference](/guide/getting-started#cli-reference).
+
+### `PkgExecOptions` fields
+
+| Field              | Type                                     | CLI equivalent         | Notes                                                |
+| ------------------ | ---------------------------------------- | ---------------------- | ---------------------------------------------------- |
+| `input`            | `string`                                 | positional `<input>`   | **Required.** Entry file or directory.               |
+| `targets`          | `string \| string[]`                     | `--targets`            | e.g. `'host'` or `['node22-linux-x64', ...]`.        |
+| `config`           | `string`                                 | `--config`             | Path to `package.json` or standalone config JSON.    |
+| `output`           | `string`                                 | `--output`             | Output file name or template.                        |
+| `outputPath`       | `string`                                 | `--out-path`           | Output directory (mutually exclusive with `output`). |
+| `compress`         | `'None' \| 'Brotli' \| 'GZip' \| 'Zstd'` | `--compress`           | Default `'None'`.                                    |
+| `sea`              | `boolean`                                | `--sea`                | Use Single Executable Application mode.              |
+| `bakeOptions`      | `string \| string[]`                     | `--options`            | Node/V8 flags baked into the binary.                 |
+| `debug`            | `boolean`                                | `--debug`              | Verbose packaging logs.                              |
+| `build`            | `boolean`                                | `--build`              | Build base binaries from source.                     |
+| `bytecode`         | `boolean`                                | `--no-bytecode`        | Default `true`. Set `false` to ship plain JS.        |
+| `nativeBuild`      | `boolean`                                | `--no-native-build`    | Default `true`.                                      |
+| `fallbackToSource` | `boolean`                                | `--fallback-to-source` | Ship source when bytecode compile fails.             |
+| `public`           | `boolean`                                | `--public`             | Top-level project is public.                         |
+| `publicPackages`   | `string \| string[]`                     | `--public-packages`    | Use `['*']` for all.                                 |
+| `noDictionary`     | `string \| string[]`                     | `--no-dict`            | Use `['*']` to disable all dictionaries.             |
+| `signature`        | `boolean`                                | `--no-signature`       | Default `true` (macOS signing when applicable).      |
 
 ## Build a full release pipeline
 
@@ -60,17 +97,14 @@ async function build() {
   await rm(DIST, { recursive: true, force: true });
   await mkdir(DIST, { recursive: true });
 
-  await exec([
-    '.',
-    '--targets',
-    TARGETS.join(','),
-    '--out-path',
-    DIST,
-    '--compress',
-    'Brotli',
-  ]);
+  await exec({
+    input: '.',
+    targets: TARGETS,
+    outputPath: DIST,
+    compress: 'Brotli',
+  });
 
-  console.log(`✅ built ${TARGETS.length} binaries into ${path.resolve(DIST)}`);
+  console.log(`built ${TARGETS.length} binaries into ${path.resolve(DIST)}`);
 }
 
 build().catch((err) => {

--- a/docs-site/guide/api.md
+++ b/docs-site/guide/api.md
@@ -58,25 +58,25 @@ The strings are exactly what you'd pass on the command line — see [Getting sta
 
 ### `PkgExecOptions` fields
 
-| Field              | Type                                     | CLI equivalent         | Notes                                                |
-| ------------------ | ---------------------------------------- | ---------------------- | ---------------------------------------------------- |
-| `input`            | `string`                                 | positional `<input>`   | **Required.** Entry file or directory.               |
-| `targets`          | `string \| string[]`                     | `--targets`            | e.g. `'host'` or `['node22-linux-x64', ...]`.        |
-| `config`           | `string`                                 | `--config`             | Path to `package.json` or standalone config JSON.    |
-| `output`           | `string`                                 | `--output`             | Output file name or template.                        |
-| `outputPath`       | `string`                                 | `--out-path`           | Output directory (mutually exclusive with `output`). |
-| `compress`         | `'None' \| 'Brotli' \| 'GZip' \| 'Zstd'` | `--compress`           | Default `'None'`.                                    |
-| `sea`              | `boolean`                                | `--sea`                | Use Single Executable Application mode.              |
-| `bakeOptions`      | `string \| string[]`                     | `--options`            | Node/V8 flags baked into the binary.                 |
-| `debug`            | `boolean`                                | `--debug`              | Verbose packaging logs.                              |
-| `build`            | `boolean`                                | `--build`              | Build base binaries from source.                     |
-| `bytecode`         | `boolean`                                | `--no-bytecode`        | Default `true`. Set `false` to ship plain JS.        |
-| `nativeBuild`      | `boolean`                                | `--no-native-build`    | Default `true`.                                      |
-| `fallbackToSource` | `boolean`                                | `--fallback-to-source` | Ship source when bytecode compile fails.             |
-| `public`           | `boolean`                                | `--public`             | Top-level project is public.                         |
-| `publicPackages`   | `string \| string[]`                     | `--public-packages`    | Use `['*']` for all.                                 |
-| `noDictionary`     | `string \| string[]`                     | `--no-dict`            | Use `['*']` to disable all dictionaries.             |
-| `signature`        | `boolean`                                | `--no-signature`       | Default `true` (macOS signing when applicable).      |
+| Field              | Type                                     | CLI equivalent         | Notes                                                       |
+| ------------------ | ---------------------------------------- | ---------------------- | ----------------------------------------------------------- |
+| `input`            | `string`                                 | positional `<input>`   | **Required.** Entry file or directory.                      |
+| `targets`          | `string[]`                               | `--targets`            | e.g. `['host']` or `['node22-linux-x64', ...]`.             |
+| `config`           | `string`                                 | `--config`             | Path to `package.json` or standalone config JSON.           |
+| `output`           | `string`                                 | `--output`             | Output file name or template.                               |
+| `outputPath`       | `string`                                 | `--out-path`           | Output directory (mutually exclusive with `output`).        |
+| `compress`         | `'None' \| 'Brotli' \| 'GZip' \| 'Zstd'` | `--compress`           | Default `'None'`.                                           |
+| `sea`              | `boolean`                                | `--sea`                | Use Single Executable Application mode.                     |
+| `bakeOptions`      | `string \| string[]`                     | `--options`            | Node/V8 flags baked into the binary (e.g. `['expose-gc']`). |
+| `debug`            | `boolean`                                | `--debug`              | Verbose packaging logs.                                     |
+| `build`            | `boolean`                                | `--build`              | Build base binaries from source.                            |
+| `bytecode`         | `boolean`                                | `--no-bytecode`        | Default `true`. Set `false` to ship plain JS.               |
+| `nativeBuild`      | `boolean`                                | `--no-native-build`    | Default `true`.                                             |
+| `fallbackToSource` | `boolean`                                | `--fallback-to-source` | Ship source when bytecode compile fails.                    |
+| `public`           | `boolean`                                | `--public`             | Top-level project is public.                                |
+| `publicPackages`   | `string[]`                               | `--public-packages`    | Use `['*']` for all.                                        |
+| `noDictionary`     | `string[]`                               | `--no-dict`            | Use `['*']` to disable all dictionaries.                    |
+| `signature`        | `boolean`                                | `--no-signature`       | Default `true` (macOS signing when applicable).             |
 
 ## Build a full release pipeline
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -104,6 +104,9 @@ module.exports = [
       'no-continue': 'off',
       'no-param-reassign': 'off',
       'no-restricted-syntax': 'off',
+      // Core `no-redeclare` doesn't understand TypeScript function overloads.
+      'no-redeclare': 'off',
+      '@typescript-eslint/no-redeclare': 'error',
     },
   },
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -235,7 +235,57 @@ async function needViaCache(target: NodeTarget) {
   return c;
 }
 
-function optionsToArgv(options: PkgExecOptions): string[] {
+const FLAG_DEFAULTS = {
+  bytecode: true,
+  'native-build': true,
+  signature: true,
+};
+
+const MINIMIST_OPTS = {
+  boolean: [
+    'b',
+    'build',
+    'bytecode',
+    'native-build',
+    'd',
+    'debug',
+    'fallback-to-source',
+    'h',
+    'help',
+    'public',
+    'v',
+    'version',
+    'signature',
+    'sea',
+  ],
+  string: [
+    '_',
+    'c',
+    'config',
+    'o',
+    'options',
+    'output',
+    'outdir',
+    'out-dir',
+    'out-path',
+    'public-packages',
+    'no-dict',
+    't',
+    'target',
+    'targets',
+    'C',
+    'compress',
+  ],
+  default: FLAG_DEFAULTS,
+};
+
+function joinList(v: string | string[] | undefined): string | undefined {
+  if (v === undefined) return undefined;
+  const joined = Array.isArray(v) ? v.join(',') : v;
+  return joined === '' ? undefined : joined;
+}
+
+function optionsToParsed(options: PkgExecOptions): minimist.ParsedArgs {
   if (!options || typeof options !== 'object') {
     throw wasReported('exec() options must be an object');
   }
@@ -244,36 +294,35 @@ function optionsToArgv(options: PkgExecOptions): string[] {
     throw wasReported('exec() options.input is required and must be a string');
   }
 
-  const argv: string[] = [];
-
-  const pushList = (flag: string, value: string | string[] | undefined) => {
-    if (value === undefined) return;
-    const joined = Array.isArray(value) ? value.join(',') : value;
-    if (joined !== '') argv.push(flag, joined);
+  const argv: minimist.ParsedArgs = {
+    ...FLAG_DEFAULTS,
+    _: [options.input],
   };
 
-  pushList('--targets', options.targets);
-  if (options.config !== undefined) argv.push('--config', options.config);
-  if (options.output !== undefined) argv.push('--output', options.output);
-  if (options.outputPath !== undefined) {
-    argv.push('--out-path', options.outputPath);
-  }
-  if (options.compress !== undefined && options.compress !== 'None') {
-    argv.push('--compress', options.compress);
-  }
-  if (options.sea) argv.push('--sea');
-  pushList('--options', options.bakeOptions);
-  if (options.debug) argv.push('--debug');
-  if (options.build) argv.push('--build');
-  if (options.bytecode === false) argv.push('--no-bytecode');
-  if (options.nativeBuild === false) argv.push('--no-native-build');
-  if (options.fallbackToSource) argv.push('--fallback-to-source');
-  if (options.public) argv.push('--public');
-  pushList('--public-packages', options.publicPackages);
-  pushList('--no-dict', options.noDictionary);
-  if (options.signature === false) argv.push('--no-signature');
+  const setIfDefined = (key: string, value: unknown) => {
+    if (value !== undefined) argv[key] = value;
+  };
 
-  argv.push(options.input);
+  setIfDefined('targets', joinList(options.targets));
+  setIfDefined('config', options.config);
+  setIfDefined('output', options.output);
+  setIfDefined('out-path', options.outputPath);
+  setIfDefined(
+    'compress',
+    options.compress === 'None' ? undefined : options.compress,
+  );
+  setIfDefined('sea', options.sea);
+  setIfDefined('options', joinList(options.bakeOptions));
+  setIfDefined('debug', options.debug);
+  setIfDefined('build', options.build);
+  setIfDefined('bytecode', options.bytecode);
+  setIfDefined('native-build', options.nativeBuild);
+  setIfDefined('fallback-to-source', options.fallbackToSource);
+  setIfDefined('public', options.public);
+  setIfDefined('public-packages', joinList(options.publicPackages));
+  setIfDefined('no-dict', joinList(options.noDictionary));
+  setIfDefined('signature', options.signature);
+
   return argv;
 }
 
@@ -282,46 +331,9 @@ export async function exec(options: PkgExecOptions): Promise<void>;
 export async function exec(
   argvOrOptions: string[] | PkgExecOptions,
 ): Promise<void> {
-  const argv2 = Array.isArray(argvOrOptions)
-    ? argvOrOptions
-    : optionsToArgv(argvOrOptions);
-  const argv = minimist(argv2, {
-    boolean: [
-      'b',
-      'build',
-      'bytecode',
-      'native-build',
-      'd',
-      'debug',
-      'fallback-to-source',
-      'h',
-      'help',
-      'public',
-      'v',
-      'version',
-      'signature',
-      'sea',
-    ],
-    string: [
-      '_',
-      'c',
-      'config',
-      'o',
-      'options',
-      'output',
-      'outdir',
-      'out-dir',
-      'out-path',
-      'public-packages',
-      'no-dict',
-      't',
-      'target',
-      'targets',
-      'C',
-      'compress',
-    ],
-    default: { bytecode: true, 'native-build': true, signature: true },
-  });
+  const argv = Array.isArray(argvOrOptions)
+    ? minimist(argvOrOptions, MINIMIST_OPTS)
+    : optionsToParsed(argvOrOptions);
 
   if (argv.h || argv.help) {
     help();

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -279,7 +279,7 @@ const MINIMIST_OPTS = {
   default: FLAG_DEFAULTS,
 };
 
-function joinList(v: string | string[] | undefined): string | undefined {
+function joinList(v: string[] | string | undefined): string | undefined {
   if (v === undefined) return undefined;
   const joined = Array.isArray(v) ? v.join(',') : v;
   return joined === '' ? undefined : joined;
@@ -307,10 +307,7 @@ function optionsToParsed(options: PkgExecOptions): minimist.ParsedArgs {
   setIfDefined('config', options.config);
   setIfDefined('output', options.output);
   setIfDefined('out-path', options.outputPath);
-  setIfDefined(
-    'compress',
-    options.compress === 'None' ? undefined : options.compress,
-  );
+  setIfDefined('compress', options.compress);
   setIfDefined('sea', options.sea);
   setIfDefined('options', joinList(options.bakeOptions));
   setIfDefined('debug', options.debug);

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -14,11 +14,19 @@ import producer from './producer';
 import refine from './refiner';
 import { shutdown } from './fabricator';
 import walk, { Marker, WalkerParams } from './walker';
-import { Target, NodeTarget, SymLinks } from './types';
+import {
+  Target,
+  NodeTarget,
+  SymLinks,
+  PkgExecOptions,
+  PkgCompressType,
+} from './types';
 import { CompressType } from './compress_type';
 import { signMachOExecutable } from './mach-o';
 import pkgOptions from './options';
 import sea, { seaEnhanced, signMacOSIfNeeded } from './sea';
+
+export type { PkgExecOptions, PkgCompressType };
 
 const { version } = JSON.parse(
   readFileSync(path.join(__dirname, '../package.json'), 'utf-8'),
@@ -227,7 +235,56 @@ async function needViaCache(target: NodeTarget) {
   return c;
 }
 
-export async function exec(argv2: string[]) {
+function optionsToArgv(options: PkgExecOptions): string[] {
+  if (!options || typeof options !== 'object') {
+    throw wasReported('exec() options must be an object');
+  }
+
+  if (!options.input || typeof options.input !== 'string') {
+    throw wasReported('exec() options.input is required and must be a string');
+  }
+
+  const argv: string[] = [];
+
+  const pushList = (flag: string, value: string | string[] | undefined) => {
+    if (value === undefined) return;
+    const joined = Array.isArray(value) ? value.join(',') : value;
+    if (joined !== '') argv.push(flag, joined);
+  };
+
+  pushList('--targets', options.targets);
+  if (options.config !== undefined) argv.push('--config', options.config);
+  if (options.output !== undefined) argv.push('--output', options.output);
+  if (options.outputPath !== undefined) {
+    argv.push('--out-path', options.outputPath);
+  }
+  if (options.compress !== undefined && options.compress !== 'None') {
+    argv.push('--compress', options.compress);
+  }
+  if (options.sea) argv.push('--sea');
+  pushList('--options', options.bakeOptions);
+  if (options.debug) argv.push('--debug');
+  if (options.build) argv.push('--build');
+  if (options.bytecode === false) argv.push('--no-bytecode');
+  if (options.nativeBuild === false) argv.push('--no-native-build');
+  if (options.fallbackToSource) argv.push('--fallback-to-source');
+  if (options.public) argv.push('--public');
+  pushList('--public-packages', options.publicPackages);
+  pushList('--no-dict', options.noDictionary);
+  if (options.signature === false) argv.push('--no-signature');
+
+  argv.push(options.input);
+  return argv;
+}
+
+export async function exec(argv: string[]): Promise<void>;
+export async function exec(options: PkgExecOptions): Promise<void>;
+export async function exec(
+  argvOrOptions: string[] | PkgExecOptions,
+): Promise<void> {
+  const argv2 = Array.isArray(argvOrOptions)
+    ? argvOrOptions
+    : optionsToArgv(argvOrOptions);
   const argv = minimist(argv2, {
     boolean: [
       'b',

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -109,3 +109,42 @@ export interface SeaEnhancedOptions {
 }
 
 export type SymLinks = Record<string, string>;
+
+export type PkgCompressType = keyof typeof CompressType;
+
+export interface PkgExecOptions {
+  /** Entry file or directory (required). */
+  input: string;
+  /** Target spec(s), e.g. 'node22-linux-x64' or 'host'. */
+  targets?: string | string[];
+  /** Path to a `package.json` or standalone config JSON. */
+  config?: string;
+  /** Output file name or template for multiple targets. */
+  output?: string;
+  /** Directory to save the output executable(s). Mutually exclusive with `output`. */
+  outputPath?: string;
+  /** VFS compression algorithm. Default `'None'`. */
+  compress?: PkgCompressType;
+  /** Use Node.js Single Executable Application mode. */
+  sea?: boolean;
+  /** Bake Node/V8 CLI options into the executable (e.g. `['expose-gc']`). */
+  bakeOptions?: string | string[];
+  /** Enable verbose packaging logs. */
+  debug?: boolean;
+  /** Build base binaries from source instead of downloading prebuilt ones. */
+  build?: boolean;
+  /** Compile bytecode. Default `true`. Set to `false` to ship plain JS. */
+  bytecode?: boolean;
+  /** Build native addons. Default `true`. */
+  nativeBuild?: boolean;
+  /** If bytecode compilation fails for a file, ship it as plain source. */
+  fallbackToSource?: boolean;
+  /** Treat the top-level project as public (faster, discloses sources). */
+  public?: boolean;
+  /** Package names to treat as public. `['*']` for all packages. */
+  publicPackages?: string | string[];
+  /** Package names to ignore dictionaries for. `['*']` to disable all. */
+  noDictionary?: string | string[];
+  /** Sign macOS binaries when applicable. Default `true`. */
+  signature?: boolean;
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -115,8 +115,8 @@ export type PkgCompressType = keyof typeof CompressType;
 export interface PkgExecOptions {
   /** Entry file or directory (required). */
   input: string;
-  /** Target spec(s), e.g. 'node22-linux-x64' or 'host'. */
-  targets?: string | string[];
+  /** Target specs, e.g. `['node22-linux-x64']` or `['host']`. */
+  targets?: string[];
   /** Path to a `package.json` or standalone config JSON. */
   config?: string;
   /** Output file name or template for multiple targets. */
@@ -142,9 +142,9 @@ export interface PkgExecOptions {
   /** Treat the top-level project as public (faster, discloses sources). */
   public?: boolean;
   /** Package names to treat as public. `['*']` for all packages. */
-  publicPackages?: string | string[];
+  publicPackages?: string[];
   /** Package names to ignore dictionaries for. `['*']` to disable all. */
-  noDictionary?: string | string[];
+  noDictionary?: string[];
   /** Sign macOS binaries when applicable. Default `true`. */
   signature?: boolean;
 }

--- a/test/test-50-api-options/main.js
+++ b/test/test-50-api-options/main.js
@@ -11,6 +11,7 @@ assert(__dirname === process.cwd());
 
 const target = process.argv[2] || 'host';
 const input = './test-x-index.js';
+const gcInput = './test-y-index.js';
 const output = './test-output.exe';
 
 utils.mkdirp.sync(path.dirname(output));
@@ -18,32 +19,71 @@ utils.mkdirp.sync(path.dirname(output));
 const { exec } = require('../../');
 
 async function run() {
-  // typed options object form
+  // typed options object form — minimal
   await exec({
     input,
     targets: [target],
     output,
   });
-
-  const result = utils.spawn.sync(output, [], {});
-  assert.strictEqual(result, '42\n');
+  assert.strictEqual(utils.spawn.sync(output, [], {}), '42\n');
   utils.vacuum.sync(output);
 
   // array form still works (backward compat)
   await exec(['--target', target, '--output', output, input]);
-  const result2 = utils.spawn.sync(output, [], {});
-  assert.strictEqual(result2, '42\n');
+  assert.strictEqual(utils.spawn.sync(output, [], {}), '42\n');
   utils.vacuum.sync(output);
 
-  // input validation
+  // exercise field mappings that would silently no-op on a typo in
+  // optionsToParsed: bakeOptions reaches the packaged binary only if the
+  // '--options' key name is correct.
+  await exec({
+    input: gcInput,
+    targets: [target],
+    output,
+    bakeOptions: ['expose-gc'],
+    publicPackages: ['*'],
+    noDictionary: ['*'],
+  });
+  assert.strictEqual(utils.spawn.sync(output, [], {}), 'gc-on\n');
+  utils.vacuum.sync(output);
+
+  // compression path
+  await exec({
+    input,
+    targets: [target],
+    output,
+    compress: 'Brotli',
+  });
+  assert.strictEqual(utils.spawn.sync(output, [], {}), '42\n');
+  utils.vacuum.sync(output);
+
+  // input validation — missing input
+  await assertThrows(
+    () => exec({}),
+    'options.input',
+    'exec({}) should have thrown',
+  );
+
+  // input validation — non-object
+  await assertThrows(
+    () => exec(null),
+    'must be an object',
+    'exec(null) should have thrown',
+  );
+}
+
+async function assertThrows(fn, expectedSubstring, message) {
   let threw = false;
   try {
-    await exec({});
+    await fn();
   } catch (err) {
     threw = true;
-    assert(/input/.test(err.message), `unexpected error: ${err.message}`);
+    assert(
+      err.message.includes(expectedSubstring),
+      `unexpected error: ${err.message}`,
+    );
   }
-  assert(threw, 'exec({}) should have thrown');
+  assert(threw, message);
 }
 
 run().catch(function (error) {

--- a/test/test-50-api-options/main.js
+++ b/test/test-50-api-options/main.js
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+
+'use strict';
+
+const path = require('path');
+const assert = require('assert');
+const utils = require('../utils.js');
+
+assert(!module.parent);
+assert(__dirname === process.cwd());
+
+const target = process.argv[2] || 'host';
+const input = './test-x-index.js';
+const output = './test-output.exe';
+
+utils.mkdirp.sync(path.dirname(output));
+
+const { exec } = require('../../');
+
+async function run() {
+  // typed options object form
+  await exec({
+    input,
+    targets: [target],
+    output,
+  });
+
+  const result = utils.spawn.sync(output, [], {});
+  assert.strictEqual(result, '42\n');
+  utils.vacuum.sync(output);
+
+  // array form still works (backward compat)
+  await exec(['--target', target, '--output', output, input]);
+  const result2 = utils.spawn.sync(output, [], {});
+  assert.strictEqual(result2, '42\n');
+  utils.vacuum.sync(output);
+
+  // input validation
+  let threw = false;
+  try {
+    await exec({});
+  } catch (err) {
+    threw = true;
+    assert(/input/.test(err.message), `unexpected error: ${err.message}`);
+  }
+  assert(threw, 'exec({}) should have thrown');
+}
+
+run().catch(function (error) {
+  console.error(error);
+  process.exit(2);
+});

--- a/test/test-50-api-options/test-x-index.js
+++ b/test/test-50-api-options/test-x-index.js
@@ -1,0 +1,3 @@
+'use strict';
+
+console.log(42);

--- a/test/test-50-api-options/test-y-index.js
+++ b/test/test-50-api-options/test-y-index.js
@@ -1,0 +1,3 @@
+'use strict';
+
+console.log(typeof global.gc === 'function' ? 'gc-on' : 'gc-off');


### PR DESCRIPTION
## Summary

- Adds a typed `PkgExecOptions` interface for the public `exec()` API while preserving the existing `string[]` overload for full backward compatibility.
- Exports `PkgExecOptions` and `PkgCompressType` from the package entry point (surfaces in `lib-es5/index.d.ts`).
- Documents both forms on the docs site with a field-by-field table.

## Design

The options path normalizes into CLI-style argv via a small `optionsToArgv()` helper and then feeds the **existing** minimist pipeline. Defaults (`bytecode`, `nativeBuild`, `signature` → `true`) and validation stay in one place — zero behavior drift between the two entry forms.

`PkgCompressType` is derived from the existing `CompressType` enum via `keyof typeof` so the public union can't drift from the internal representation.

`PkgExecOptions` is kept distinct from the internal `PkgOptions` (which models the `"pkg"` section of `package.json`). They describe different layers — build content vs. driver knobs — and forcing shared ancestry would either leak internals (`patches`, `dictionary`, `log`) into the public surface or require a contrived shared base with only 2–3 fields.

## Changes

| File | Change |
| --- | --- |
| `lib/types.ts` | Add `PkgExecOptions` + `PkgCompressType` (derived from `CompressType`). |
| `lib/index.ts` | Add `optionsToArgv()` + overloaded `exec()`; re-export types. |
| `eslint.config.js` | Swap core `no-redeclare` → `@typescript-eslint/no-redeclare` (core rule misfires on TS function overloads). |
| `docs-site/guide/api.md` | Document the options-object form with a field table; update release-pipeline example. |
| `test/test-50-api-options/` | Smoke test covering options form, argv form (backward compat), and `input` validation. |

## Test plan

- [x] `yarn build` clean
- [x] `yarn lint` clean
- [x] `test-50-api-options` passes on host
- [x] `test-50-api` (existing programmatic-API test using argv form) still passes
- [ ] CI green

closes #242

🤖 Generated with [Claude Code](https://claude.com/claude-code)