### PR TITLE
feat: auto-discover .pkgrc / pkg.config.{js,cjs,mjs}

### DIFF
--- a/docs-site/guide/configuration.md
+++ b/docs-site/guide/configuration.md
@@ -39,6 +39,54 @@ You may also specify arrays of globs:
 
 Call `pkg package.json` or `pkg .` to make use of the `package.json` configuration.
 
+## Standalone config file
+
+If you prefer to keep `package.json` clean, drop a dedicated config file next to your entry point. `pkg` looks for these names, in order, and uses the first one it finds:
+
+1. `.pkgrc` — JSON
+2. `.pkgrc.json` — JSON
+3. `pkg.config.js` — CommonJS or ESM (follows `"type"` in `package.json`)
+4. `pkg.config.cjs` — CommonJS
+5. `pkg.config.mjs` — ESM (use this when you need to export functions)
+
+The file contains a bare pkg config (no `pkg` wrapper):
+
+```json
+{
+  "scripts": "build/**/*.js",
+  "assets": "views/**/*",
+  "targets": ["node22-linux-x64"],
+  "outputPath": "dist"
+}
+```
+
+```js
+// pkg.config.js — use this when you need comments or computed values
+module.exports = {
+  scripts: 'build/**/*.js',
+  assets: ['views/**/*', process.env.EXTRA_ASSET].filter(Boolean),
+  targets: ['node22-linux-x64'],
+  outputPath: 'dist',
+};
+```
+
+```js
+// pkg.config.mjs — ESM; use this to expose functions
+export default {
+  scripts: 'build/**/*.js',
+  targets: ['node22-linux-x64'],
+  outputPath: 'dist',
+};
+```
+
+Precedence (highest to lowest):
+
+1. `--config <file>` passed on the CLI
+2. Auto-discovered `.pkgrc` / `.pkgrc.json` / `pkg.config.js` / `pkg.config.cjs`
+3. `pkg` field in `package.json`
+
+When both a pkgrc and a `pkg` field in `package.json` are present, the pkgrc wins and `pkg` logs a warning. `name` and `bin` are still read from `package.json`.
+
 ## Full schema
 
 | Key            | Type             | Description                                                                                                                      |

--- a/docs-site/guide/configuration.md
+++ b/docs-site/guide/configuration.md
@@ -82,7 +82,7 @@ export default {
 Precedence (highest to lowest):
 
 1. `--config <file>` passed on the CLI
-2. Auto-discovered `.pkgrc` / `.pkgrc.json` / `pkg.config.js` / `pkg.config.cjs`
+2. Auto-discovered `.pkgrc` / `.pkgrc.json` / `pkg.config.js` / `pkg.config.cjs` / `pkg.config.mjs`
 3. `pkg` field in `package.json`
 
 When both a pkgrc and a `pkg` field in `package.json` are present, the pkgrc wins and `pkg` logs a warning. `name` and `bin` are still read from `package.json`.

--- a/lib/help.ts
+++ b/lib/help.ts
@@ -9,8 +9,8 @@ export default function help() {
     -h, --help           output usage information
     -v, --version        output pkg version
     -t, --targets        comma-separated list of targets (see examples)
-    -c, --config         package.json or any json file with top-level config
-                         (auto-discovered as .pkgrc, .pkgrc.json, pkg.config.js, .cjs or .mjs)
+    -c, --config         package.json or a .json, .js, .cjs, or .mjs file with top-level config
+                         (auto-discovered as .pkgrc, .pkgrc.json, pkg.config.js, pkg.config.cjs, or pkg.config.mjs)
     --options            bake v8 options into executable to run with them on
     -o, --output         output file name or template for several files
     --out-path           path to save output one or more executables

--- a/lib/help.ts
+++ b/lib/help.ts
@@ -10,6 +10,7 @@ export default function help() {
     -v, --version        output pkg version
     -t, --targets        comma-separated list of targets (see examples)
     -c, --config         package.json or any json file with top-level config
+                         (auto-discovered as .pkgrc, .pkgrc.json, pkg.config.js, .cjs or .mjs)
     --options            bake v8 options into executable to run with them on
     -o, --output         output file name or template for several files
     --out-path           path to save output one or more executables

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -4,6 +4,7 @@ import { mkdir, readFile, rm, stat } from 'fs/promises';
 import minimist from 'minimist';
 import { need, system } from '@yao-pkg/pkg-fetch';
 import path from 'path';
+import { pathToFileURL } from 'url';
 
 import { log, wasReported } from './log';
 import help from './help';
@@ -28,14 +29,53 @@ function isConfiguration(file: string) {
   return isPackageJson(file) || file.endsWith('.config.json');
 }
 
+// Auto-discovered config filenames, in precedence order. First match wins.
+const PKGRC_FILENAMES = [
+  '.pkgrc',
+  '.pkgrc.json',
+  'pkg.config.js',
+  'pkg.config.cjs',
+  'pkg.config.mjs',
+];
+
+function findPkgrc(baseDir: string): string | undefined {
+  for (const name of PKGRC_FILENAMES) {
+    const candidate = path.join(baseDir, name);
+    if (existsSync(candidate)) {
+      return candidate;
+    }
+  }
+  return undefined;
+}
+
+// TypeScript with `module: commonjs` rewrites `import(...)` as `require(...)`,
+// which breaks ESM loading. `new Function(...)` forces a genuine dynamic import.
+const nativeImport = new Function('specifier', 'return import(specifier)') as (
+  specifier: string,
+) => Promise<{ default?: unknown; [k: string]: unknown }>;
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+async function loadPkgrc(file: string): Promise<any> {
+  const base = path.basename(file);
+  // `.pkgrc` has no extension and `.pkgrc.json` is JSON only — parse directly.
+  if (base === '.pkgrc' || file.endsWith('.json')) {
+    return JSON.parse(readFileSync(file, 'utf-8'));
+  }
+  // .js / .cjs / .mjs — load via dynamic import so ESM configs (and projects
+  // with `"type": "module"`) work. `.mjs` is the portable way to expose
+  // functions in config (planned for future options like hooks/transforms).
+  const mod = await nativeImport(pathToFileURL(file).href);
+  return mod.default ?? mod;
+}
+
 function buildMarker(
   configJson: Record<string, unknown> | undefined,
-  config: string,
+  config: string | undefined,
   inputJson: Record<string, unknown> | undefined,
   input: string,
 ): Marker {
   const marker: Marker = configJson
-    ? { config: configJson, base: path.dirname(config), configPath: config }
+    ? { config: configJson, base: path.dirname(config!), configPath: config! }
     : {
         config: inputJson || {},
         base: path.dirname(input),
@@ -393,10 +433,23 @@ export async function exec(argv2: string[]) {
 
   // config
 
-  let config = argv.c || argv.config;
+  const explicitConfig = argv.c || argv.config;
+  let config: string | undefined = explicitConfig;
 
-  if (inputJson && config) {
+  if (inputJson && explicitConfig) {
     throw wasReported("Specify either 'package.json' or config. Not both");
+  }
+
+  // Auto-discover .pkgrc / .pkgrc.json / pkg.config.js / pkg.config.cjs in the
+  // input's directory when --config wasn't passed. A pkgrc is complementary to
+  // package.json: metadata (name/bin) comes from package.json, pkg config from
+  // the pkgrc.
+  if (!explicitConfig) {
+    const discovered = findPkgrc(path.dirname(input));
+    if (discovered) {
+      config = discovered;
+      log.info(`Using config ${path.relative(process.cwd(), discovered)}`);
+    }
   }
 
   // configJson
@@ -409,8 +462,7 @@ export async function exec(argv2: string[]) {
       throw wasReported('Config file does not exist', [config]);
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    configJson = require(config); // may be either json or js
+    configJson = await loadPkgrc(config); // json / js / cjs / mjs
 
     if (
       !configJson.name &&
@@ -418,9 +470,16 @@ export async function exec(argv2: string[]) {
       !configJson.dependencies &&
       !configJson.pkg
     ) {
-      // package.json not detected
+      // bare pkg config → wrap it
       configJson = { pkg: configJson };
     }
+  }
+
+  if (!explicitConfig && config && inputJson?.pkg) {
+    log.warn(
+      `Both ${path.basename(config)} and "pkg" field in package.json were found. ` +
+        `The ${path.basename(config)} file takes precedence.`,
+    );
   }
 
   // output, outputPath
@@ -451,10 +510,10 @@ export async function exec(argv2: string[]) {
     }
 
     if (!outputPath) {
-      if (inputJson && inputJson.pkg) {
-        outputPath = inputJson.pkg.outputPath;
-      } else if (configJson && configJson.pkg) {
+      if (configJson && configJson.pkg) {
         outputPath = configJson.pkg.outputPath;
+      } else if (inputJson && inputJson.pkg) {
+        outputPath = inputJson.pkg.outputPath;
       }
 
       outputPath = outputPath || '';
@@ -483,10 +542,10 @@ export async function exec(argv2: string[]) {
   if (!targets.length) {
     let jsonTargets;
 
-    if (inputJson && inputJson.pkg) {
-      jsonTargets = inputJson.pkg.targets;
-    } else if (configJson && configJson.pkg) {
+    if (configJson && configJson.pkg) {
       jsonTargets = configJson.pkg.targets;
+    } else if (inputJson && inputJson.pkg) {
+      jsonTargets = inputJson.pkg.targets;
     }
 
     if (jsonTargets) {

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -440,10 +440,10 @@ export async function exec(argv2: string[]) {
     throw wasReported("Specify either 'package.json' or config. Not both");
   }
 
-  // Auto-discover .pkgrc / .pkgrc.json / pkg.config.js / pkg.config.cjs in the
-  // input's directory when --config wasn't passed. A pkgrc is complementary to
-  // package.json: metadata (name/bin) comes from package.json, pkg config from
-  // the pkgrc.
+  // Auto-discover .pkgrc / .pkgrc.json / pkg.config.js / pkg.config.cjs /
+  // pkg.config.mjs in the input's directory when --config wasn't passed. A
+  // pkgrc is complementary to package.json: metadata (name/bin) comes from
+  // package.json, pkg config from the pkgrc.
   if (!explicitConfig) {
     const discovered = findPkgrc(path.dirname(input));
     if (discovered) {

--- a/test/test-46-pkgrc-js/main.js
+++ b/test/test-46-pkgrc-js/main.js
@@ -1,0 +1,21 @@
+#!/usr/bin/env node
+
+'use strict';
+
+const assert = require('assert');
+const utils = require('../utils.js');
+
+assert(!module.parent);
+assert(__dirname === process.cwd());
+
+// Input is a plain JS file — pkg.config.js in the same directory should be
+// auto-discovered and drive the targets.
+const input = './test-x-index.js';
+
+const newcomers = ['test-x-index-linux', 'test-x-index-macos'];
+
+const before = utils.filesBefore(newcomers);
+
+utils.pkg.sync([input], { stdio: 'inherit' });
+
+utils.filesAfter(before, newcomers);

--- a/test/test-46-pkgrc-js/pkg.config.js
+++ b/test/test-46-pkgrc-js/pkg.config.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = {
+  targets: ['linux', 'macos'],
+};

--- a/test/test-46-pkgrc-js/test-x-index.js
+++ b/test/test-46-pkgrc-js/test-x-index.js
@@ -1,0 +1,3 @@
+'use strict';
+
+console.log(42);

--- a/test/test-46-pkgrc-mjs/main.js
+++ b/test/test-46-pkgrc-mjs/main.js
@@ -1,0 +1,21 @@
+#!/usr/bin/env node
+
+'use strict';
+
+const assert = require('assert');
+const utils = require('../utils.js');
+
+assert(!module.parent);
+assert(__dirname === process.cwd());
+
+// Input is a plain JS file — pkg.config.mjs in the same directory should be
+// auto-discovered via dynamic import() and drive the targets.
+const input = './test-x-index.js';
+
+const newcomers = ['test-x-index-linux', 'test-x-index-macos'];
+
+const before = utils.filesBefore(newcomers);
+
+utils.pkg.sync([input], { stdio: 'inherit' });
+
+utils.filesAfter(before, newcomers);

--- a/test/test-46-pkgrc-mjs/pkg.config.mjs
+++ b/test/test-46-pkgrc-mjs/pkg.config.mjs
@@ -1,0 +1,3 @@
+export default {
+  targets: ['linux', 'macos'],
+};

--- a/test/test-46-pkgrc-mjs/test-x-index.js
+++ b/test/test-46-pkgrc-mjs/test-x-index.js
@@ -1,0 +1,3 @@
+'use strict';
+
+console.log(42);

--- a/test/test-46-pkgrc-overrides-pkg-field/.pkgrc
+++ b/test/test-46-pkgrc-overrides-pkg-field/.pkgrc
@@ -1,0 +1,3 @@
+{
+  "targets": ["linux", "macos"]
+}

--- a/test/test-46-pkgrc-overrides-pkg-field/main.js
+++ b/test/test-46-pkgrc-overrides-pkg-field/main.js
@@ -1,0 +1,21 @@
+#!/usr/bin/env node
+
+'use strict';
+
+const assert = require('assert');
+const utils = require('../utils.js');
+
+assert(!module.parent);
+assert(__dirname === process.cwd());
+
+// Both package.json#pkg (win target) and .pkgrc (linux/macos) are present.
+// The .pkgrc takes precedence, so we should see linux + macos outputs only.
+const input = './package.json';
+
+const newcomers = ['palookaville-linux', 'palookaville-macos'];
+
+const before = utils.filesBefore(newcomers);
+
+utils.pkg.sync([input], { stdio: 'inherit' });
+
+utils.filesAfter(before, newcomers);

--- a/test/test-46-pkgrc-overrides-pkg-field/package.json
+++ b/test/test-46-pkgrc-overrides-pkg-field/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "palookaville",
+  "bin": "test-x-index.js",
+  "pkg": {
+    "targets": [
+      "win"
+    ]
+  }
+}

--- a/test/test-46-pkgrc-overrides-pkg-field/test-x-index.js
+++ b/test/test-46-pkgrc-overrides-pkg-field/test-x-index.js
@@ -1,0 +1,3 @@
+'use strict';
+
+console.log(42);

--- a/test/test-46-pkgrc/.pkgrc
+++ b/test/test-46-pkgrc/.pkgrc
@@ -1,0 +1,3 @@
+{
+  "targets": ["linux", "macos"]
+}

--- a/test/test-46-pkgrc/main.js
+++ b/test/test-46-pkgrc/main.js
@@ -1,0 +1,21 @@
+#!/usr/bin/env node
+
+'use strict';
+
+const assert = require('assert');
+const utils = require('../utils.js');
+
+assert(!module.parent);
+assert(__dirname === process.cwd());
+
+// Input is a plain JS file — .pkgrc in the same directory should be
+// auto-discovered and drive the targets.
+const input = './test-x-index.js';
+
+const newcomers = ['test-x-index-linux', 'test-x-index-macos'];
+
+const before = utils.filesBefore(newcomers);
+
+utils.pkg.sync([input], { stdio: 'inherit' });
+
+utils.filesAfter(before, newcomers);

--- a/test/test-46-pkgrc/test-x-index.js
+++ b/test/test-46-pkgrc/test-x-index.js
@@ -1,0 +1,3 @@
+'use strict';
+
+console.log(42);


### PR DESCRIPTION
## Summary

- Auto-discover a dedicated pkg config next to the input file so users no longer need to pass `--config` every time or pollute `package.json`. Discovery order: `.pkgrc` → `.pkgrc.json` → `pkg.config.js` → `pkg.config.cjs` → `pkg.config.mjs`.
- Pkgrc and `package.json` now co-exist: `package.json` supplies `name` / `bin`; pkgrc supplies the `pkg` config. If both define `pkg` config, pkgrc wins and a warning is logged.
- `.mjs` is loaded via a genuine dynamic `import()` (wrapped in `new Function` to survive the CommonJS downlevel), enabling function-valued options down the road.
- Explicit `--config` still wins over auto-discovery.

Closes #238.

## Test plan

- [x] `test-46-pkgrc` — `.pkgrc` with a plain JS input
- [x] `test-46-pkgrc-js` — `pkg.config.js` with a plain JS input
- [x] `test-46-pkgrc-mjs` — `pkg.config.mjs` (ESM) with a plain JS input
- [x] `test-46-pkgrc-overrides-pkg-field` — both `.pkgrc` and `package.json#pkg` present; pkgrc wins
- [x] Existing `test-46-input-package-json*` regression checks still pass
- [x] `tsc`, `prettier -c`, and `eslint lib test` all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)