### PR TITLE
fix: include types in npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "files": [
     "lib-es5/*.js",
     "lib-es5/index.d.ts",
+    "lib-es5/types.d.ts",
     "dictionary/*.js",
     "prelude/*.js"
   ],


### PR DESCRIPTION
was missing in
- #253