### PR TITLE
fix(pkg): ship all .d.ts files in npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "files": [
     "lib-es5/*.js",
-    "lib-es5/index.d.ts",
+    "lib-es5/*.d.ts",
     "dictionary/*.js",
     "prelude/*.js"
   ],


### PR DESCRIPTION
## Summary
- The `files` whitelist only included `lib-es5/index.d.ts`, but that file re-exports from `./types`, so the compiled `lib-es5/types.d.ts` was excluded from the published tarball.
- As a result, TypeScript consumers of the new typed `exec(options)` API added in #253 hit an unresolved-module error when compiling against `@yao-pkg/pkg@6.18.0`.
- Fix by widening the glob to `lib-es5/*.d.ts` so every generated declaration ships.

## Context
Reported by @viceice in https://github.com/yao-pkg/pkg/pull/253#discussion_r3116097290.

Verified against the published 6.18.0 tarball — `lib-es5/types.d.ts` is missing. `npm pack --dry-run` on this branch now lists all `.d.ts` files, including `types.d.ts` (4.0 kB).

## Test plan
- [x] `yarn lint` clean
- [x] `npm pack --dry-run` lists `lib-es5/types.d.ts` and every other `lib-es5/*.d.ts`
- [ ] After release, verify a TS consumer can `import type { PkgExecOptions } from '@yao-pkg/pkg'` without module-resolution errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)