### PR TITLE
fix(sea): strip trailing slashes in manifest key lookup

### DIFF
--- a/prelude/sea-vfs-setup.js
+++ b/prelude/sea-vfs-setup.js
@@ -183,17 +183,34 @@ try {
 }
 perf.end('manifest parse');
 
-// Manifest keys are always POSIX (forward slashes, no drive letter).  Gate
-// the regex on platform: on POSIX hosts paths already match, so the replace
-// is a pure allocation and we skip it (~30K calls per startup on large
-// projects).  On Windows, backslash normalization is mandatory.
+// Manifest keys are always POSIX (forward slashes, no drive letter) and
+// carry no trailing separator.  Gate the backslash regex on platform: on
+// POSIX hosts paths already match, so the replace is a pure allocation and
+// we skip it (~30K calls per startup on large projects).  On Windows,
+// backslash normalization is mandatory.
+//
+// Trailing separators are stripped on both platforms so lookups with paths
+// like `/snapshot/.../dist/` — common when a path is joined with a blank
+// segment or produced by libraries that append `/` to directory paths —
+// match the non-slashed manifest keys.  The root '/' is preserved as-is.
+// Mirrors removeTrailingSlashes() in lib/common.ts, which handles the same
+// case for the classic (non-SEA) bootstrap.
+function _stripTrailingSeps(p) {
+  var i = p.length;
+  while (i > 1) {
+    var c = p.charCodeAt(i - 1);
+    if (c !== 47 /* / */ && c !== 92 /* \\ */) break;
+    i--;
+  }
+  return i === p.length ? p : p.slice(0, i);
+}
 var toManifestKey =
   process.platform === 'win32'
     ? function (p) {
-        return p.replace(/\\/g, '/');
+        return _stripTrailingSeps(p.replace(/\\/g, '/'));
       }
     : function (p) {
-        return p;
+        return _stripTrailingSeps(p);
       };
 
 function _enoent(syscall, filePath) {

--- a/test/test-89-sea-fs-ops/index.js
+++ b/test/test-89-sea-fs-ops/index.js
@@ -40,3 +40,26 @@ try {
 } catch (e) {
   console.log('read-missing:' + e.code);
 }
+
+// Regression: directory lookups with trailing slash must resolve (issue #260).
+// Libraries like nestjs-i18n append '/' to __dirname; classic pkg strips it
+// via normalizePath, SEA must do the same in the manifest-key normalizer.
+const dirSlash = __dirname + '/';
+console.log('exists-dir-slash:' + fs.existsSync(dirSlash));
+console.log('stat-dir-slash-isDir:' + fs.statSync(dirSlash).isDirectory());
+console.log('readdir-dir-slash:' + fs.readdirSync(dirSlash).sort().join(','));
+try {
+  fs.accessSync(dirSlash);
+  console.log('accessSync-dir-slash:ok');
+} catch (e) {
+  console.log('accessSync-dir-slash:' + e.code);
+}
+
+require('fs/promises')
+  .access(dirSlash)
+  .then(function () {
+    console.log('access-promise-dir-slash:ok');
+  })
+  .catch(function (e) {
+    console.log('access-promise-dir-slash:' + e.code);
+  });

--- a/test/test-89-sea-fs-ops/main.js
+++ b/test/test-89-sea-fs-ops/main.js
@@ -31,7 +31,12 @@ const expectedOutput =
   'readdir:data.json,index.js,package.json\n' +
   'readFile:ok\n' +
   'stat-missing:ENOENT\n' +
-  'read-missing:ENOENT\n';
+  'read-missing:ENOENT\n' +
+  'exists-dir-slash:true\n' +
+  'stat-dir-slash-isDir:true\n' +
+  'readdir-dir-slash:data.json,index.js,package.json\n' +
+  'accessSync-dir-slash:ok\n' +
+  'access-promise-dir-slash:ok\n';
 
 utils.assertSeaOutput(testName, expectedOutput);
 


### PR DESCRIPTION
## Summary

- SEA provider's `toManifestKey` did not strip trailing separators, so `fs.access('/snapshot/.../dist/')` (and other APIs) missed manifest keys (stored without trailing slashes) and threw `ENOENT`.
- Classic (non-SEA) bootstrap already normalizes via `removeTrailingSlashes()` in `lib/common.ts` — this brings SEA to parity.
- Affects any library that appends `/` to directory paths (e.g. `nestjs-i18n`).

## Fix

`prelude/sea-vfs-setup.js`: added a `_stripTrailingSeps` helper (root `/` preserved; handles `/` and `\`) and applied it inside `toManifestKey` on both POSIX and Windows paths.

## Test plan

- [x] Extend `test/test-89-sea-fs-ops` with trailing-slash regression cases: `existsSync`, `statSync`, `readdirSync`, `accessSync`, `fs.promises.access`.
- [x] `yarn build && node test/test.js host no-npm test-89-sea-fs-ops` — passes on Node 22.
- [x] `yarn lint` clean.

Fixes #260

🤖 Generated with [Claude Code](https://claude.com/claude-code)