### PR TITLE
fix(sea): silence benign LIEF warnings during postject injection

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -80,6 +80,7 @@ module.exports = [
       globals: {
         ...require('globals').node,
         NodeJS: 'readonly',
+        BufferEncoding: 'readonly',
       },
     },
     rules: {

--- a/lib/sea.ts
+++ b/lib/sea.ts
@@ -80,6 +80,9 @@ const exists = async (path: string) => {
 const BENIGN_POSTJECT_STDERR =
   /^warning: (?:The signature seems corrupted!|Can't find string offset for section name '\.note)/;
 
+type StderrWrite = typeof process.stderr.write;
+type WriteCallback = (err?: Error | null) => void;
+
 /**
  * Run `fn` with `process.stderr.write` wrapped to drop known-benign
  * postject/LIEF messages. Anything that doesn't match the allow-list
@@ -88,28 +91,29 @@ const BENIGN_POSTJECT_STDERR =
  * whether `fn` resolves or rejects.
  */
 async function withFilteredPostjectStderr<T>(fn: () => Promise<T>): Promise<T> {
-  const original = process.stderr.write.bind(process.stderr);
-  const filtered: typeof process.stderr.write = function (
-    this: typeof process.stderr,
-    chunk: unknown,
-    ...rest: unknown[]
-  ): boolean {
+  const original: StderrWrite = process.stderr.write.bind(process.stderr);
+  const filtered = ((
+    chunk: string | Uint8Array,
+    encodingOrCb?: BufferEncoding | WriteCallback,
+    cb?: WriteCallback,
+  ): boolean => {
     const text =
       typeof chunk === 'string'
         ? chunk
         : Buffer.isBuffer(chunk)
           ? chunk.toString('utf8')
-          : '';
+          : Buffer.from(chunk).toString('utf8');
     if (BENIGN_POSTJECT_STDERR.test(text)) {
-      // Honor any completion callback postject / console.warn passed.
-      const cb = rest.find((a) => typeof a === 'function') as
-        | ((err?: Error | null) => void)
-        | undefined;
-      if (cb) process.nextTick(cb);
+      const callback = typeof encodingOrCb === 'function' ? encodingOrCb : cb;
+      if (callback) process.nextTick(callback);
       return true;
     }
-    return (original as (...a: unknown[]) => boolean)(chunk, ...rest);
-  } as typeof process.stderr.write;
+    // The write() overloads accept either an encoding or a callback in
+    // slot 2; disambiguate here so the correct overload is dispatched.
+    return typeof encodingOrCb === 'function'
+      ? original(chunk, encodingOrCb)
+      : original(chunk, encodingOrCb, cb);
+  }) as StderrWrite;
   process.stderr.write = filtered;
   try {
     return await fn();

--- a/lib/sea.ts
+++ b/lib/sea.ts
@@ -91,7 +91,8 @@ type WriteCallback = (err?: Error | null) => void;
  * whether `fn` resolves or rejects.
  */
 async function withFilteredPostjectStderr<T>(fn: () => Promise<T>): Promise<T> {
-  const original: StderrWrite = process.stderr.write.bind(process.stderr);
+  const original: StderrWrite = process.stderr.write;
+  const bound: StderrWrite = original.bind(process.stderr);
   const filtered = ((
     chunk: string | Uint8Array,
     encodingOrCb?: BufferEncoding | WriteCallback,
@@ -111,8 +112,8 @@ async function withFilteredPostjectStderr<T>(fn: () => Promise<T>): Promise<T> {
     // The write() overloads accept either an encoding or a callback in
     // slot 2; disambiguate here so the correct overload is dispatched.
     return typeof encodingOrCb === 'function'
-      ? original(chunk, encodingOrCb)
-      : original(chunk, encodingOrCb, cb);
+      ? bound(chunk, encodingOrCb)
+      : bound(chunk, encodingOrCb, cb);
   }) as StderrWrite;
   process.stderr.write = filtered;
   try {

--- a/lib/sea.ts
+++ b/lib/sea.ts
@@ -62,6 +62,62 @@ const exists = async (path: string) => {
   }
 };
 
+/**
+ * Benign LIEF messages printed by postject during SEA blob injection.
+ *
+ * LIEF re-parses the Node binary after postject expands the section
+ * table to make room for `NODE_SEA_BLOB`, and the pre-existing
+ * build-id / `.note.*` section-name offsets no longer resolve cleanly
+ * through `.shstrtab` — so LIEF falls back to synthetic names like
+ * `.note.100` and warns. On Mach-O the analogous "signature seems
+ * corrupted" line is also cosmetic: we re-sign the binary with
+ * `codesign` after injection (see signMachOExecutable).
+ *
+ * The warnings have no bearing on correctness of the produced
+ * executable but users reasonably assume something is wrong, so we
+ * filter them out of stderr just for the duration of the inject call.
+ */
+const BENIGN_POSTJECT_STDERR =
+  /^warning: (?:The signature seems corrupted!|Can't find string offset for section name '\.note)/;
+
+/**
+ * Run `fn` with `process.stderr.write` wrapped to drop known-benign
+ * postject/LIEF messages. Anything that doesn't match the allow-list
+ * pattern passes through unchanged, so real errors are never hidden.
+ * The original `write` is restored in a `finally` block regardless of
+ * whether `fn` resolves or rejects.
+ */
+async function withFilteredPostjectStderr<T>(fn: () => Promise<T>): Promise<T> {
+  const original = process.stderr.write.bind(process.stderr);
+  const filtered: typeof process.stderr.write = function (
+    this: typeof process.stderr,
+    chunk: unknown,
+    ...rest: unknown[]
+  ): boolean {
+    const text =
+      typeof chunk === 'string'
+        ? chunk
+        : Buffer.isBuffer(chunk)
+          ? chunk.toString('utf8')
+          : '';
+    if (BENIGN_POSTJECT_STDERR.test(text)) {
+      // Honor any completion callback postject / console.warn passed.
+      const cb = rest.find((a) => typeof a === 'function') as
+        | ((err?: Error | null) => void)
+        | undefined;
+      if (cb) process.nextTick(cb);
+      return true;
+    }
+    return (original as (...a: unknown[]) => boolean)(chunk, ...rest);
+  } as typeof process.stderr.write;
+  process.stderr.write = filtered;
+  try {
+    return await fn();
+  } finally {
+    process.stderr.write = original;
+  }
+}
+
 export type GetNodejsExecutableOptions = {
   useLocalNode?: boolean;
   nodePath?: string;
@@ -398,11 +454,13 @@ async function bake(
   // This avoids two CI issues:
   // 1. "Text file busy" race condition from concurrent npx invocations
   // 2. "Argument is not a constructor" from npx downloading incompatible versions
-  await postjectInject(outPath, 'NODE_SEA_BLOB', blobData, {
-    sentinelFuse: SEA_SENTINEL_FUSE,
-    machoSegmentName: target.platform === 'macos' ? 'NODE_SEA' : undefined,
-    overwrite: true,
-  });
+  await withFilteredPostjectStderr(() =>
+    postjectInject(outPath, 'NODE_SEA_BLOB', blobData, {
+      sentinelFuse: SEA_SENTINEL_FUSE,
+      machoSegmentName: target.platform === 'macos' ? 'NODE_SEA' : undefined,
+      overwrite: true,
+    }),
+  );
 }
 
 /**


### PR DESCRIPTION
## Summary

Every SEA build currently prints a handful of noisy warnings on stderr that look alarming but are harmless:

```
warning: The signature seems corrupted!
warning: Can't find string offset for section name '.note.100'
warning: Can't find string offset for section name '.note.100'
warning: Can't find string offset for section name '.note.100'
...
```

These come from **LIEF** inside **postject** when it re-parses the Node binary after expanding the ELF section table to make room for `NODE_SEA_BLOB`. The pre-existing `.note.*` section-name offsets and `.note.gnu.build-id` signature layout no longer resolve cleanly through `.shstrtab`, so LIEF falls back to synthetic names (`'.note.100'`) and warns. The injection itself still succeeds, and on macOS we re-sign the binary with `codesign` afterwards, so the "signature seems corrupted" line is purely cosmetic too.

Users reasonably read these as build failures and file issues, so this PR filters them out.

## Approach

Wrap the `postject.inject()` call (`lib/sea.ts`) in a tiny helper, `withFilteredPostjectStderr`, that:

- Replaces `process.stderr.write` with a version that drops only lines matching a strict allow-list regex:
  - `warning: The signature seems corrupted!`
  - `warning: Can't find string offset for section name '.note…`
- Passes everything else through unchanged — real errors from postject or anywhere else are **not** hidden.
- Restores the original `process.stderr.write` in a `finally` block so the override never leaks past the inject call.
- Honors any completion callback passed to `write` (e.g. by `console.warn`) via `process.nextTick`.

Filtering at the `process.stderr.write` layer works because postject is an Emscripten/WASM module whose `Module.printErr` defaults to `console.warn.bind(console)`, which ultimately calls `process.stderr.write`. No changes to postject are required.

### Why not the alternatives

- **Redirecting fd 2 at the OS level** would also catch C-level writes but is invasive and can swallow legitimate stderr from concurrent work (e.g. child processes or unrelated logging).
- **Patching postject** would require a fork; these messages come from LIEF, not from postject's own code.
- **Running postject in a child process** adds a fork/exec on every target — the CI issues that led us to the JS API in the first place (see the existing comment above the call) would come back.

## Test plan

- [x] `yarn build` passes
- [x] `yarn lint` clean (no Prettier / ESLint issues)
- [x] Direct postject call reproduces the LIEF warnings (A/B control)
- [x] `node lib-es5/bin.js --sea --target node22-linux-x64 …` now emits **zero** `.note.*` / "signature seems corrupted" lines
- [ ] Reviewer: sanity-check on macOS (Mach-O path) — `.note.*` warnings don't appear there, but the "signature seems corrupted" line can; re-signing then happens in `signMacOSIfNeeded`
- [ ] Reviewer: sanity-check on Windows (PE path) — LIEF is quieter here, but confirm no regressions