### PR TITLE
fix(sea): set process.pkg in worker threads

### DIFF
--- a/prelude/sea-worker-entry.js
+++ b/prelude/sea-worker-entry.js
@@ -8,4 +8,17 @@
 // TODO: Remove the node_modules/@roberts_lando/vfs patches once
 // https://github.com/platformatic/vfs/pull/9 is merged and released.
 
-require('./sea-vfs-setup');
+var vfs = require('./sea-vfs-setup');
+var shared = require('./bootstrap-shared');
+
+// Mirror the main-thread setup for process.pkg so userland checks like
+// `'pkg' in process` / `process.pkg.entrypoint` behave consistently across
+// threads. In classic (non-SEA) pkg the worker bootstrap runs the same code
+// path as the main thread and sets this up; without it, libraries that gate
+// packaged-vs-filesystem logic on `process.pkg` misbehave in workers (e.g.,
+// a pino transport that resolves paths through such a check writes into the
+// read-only snapshot and hangs waiting for `open`).
+shared.setupProcessPkg(
+  vfs.toPlatformPath(vfs.manifest.entrypoint),
+  vfs.manifest.entrypoint,
+);

--- a/test/test-90-sea-worker-threads/index.js
+++ b/test/test-90-sea-worker-threads/index.js
@@ -40,6 +40,7 @@ async function main() {
     console.log('echo:' + result.echo);
     console.log('hasFilename:' + result.hasFilename);
     console.log('hasDirname:' + result.hasDirname);
+    console.log('hasProcessPkg:' + result.hasProcessPkg);
     console.log('helperResult:' + result.helperResult);
   } catch (e) {
     console.log('worker-error:' + e.message);

--- a/test/test-90-sea-worker-threads/main.js
+++ b/test/test-90-sea-worker-threads/main.js
@@ -25,6 +25,7 @@ const expected =
   'echo:ping\n' +
   'hasFilename:true\n' +
   'hasDirname:true\n' +
+  'hasProcessPkg:true\n' +
   'helperResult:hello world\n';
 
 utils.assertSeaOutput(testName, expected);

--- a/test/test-90-sea-worker-threads/worker.js
+++ b/test/test-90-sea-worker-threads/worker.js
@@ -6,6 +6,16 @@ const { parentPort, workerData } = require('worker_threads');
 const hasFilename = typeof __filename === 'string' && __filename.length > 0;
 const hasDirname = typeof __dirname === 'string' && __dirname.length > 0;
 
+// Mirrors the main-thread compatibility contract: classic pkg sets
+// `process.pkg` in every thread, so any userland library that gates
+// behavior on `'pkg' in process` (a common pattern for picking cwd vs
+// __dirname when resolving runtime paths) expects this in workers too.
+const hasProcessPkg =
+  typeof process.pkg === 'object' &&
+  process.pkg !== null &&
+  typeof process.pkg.entrypoint === 'string' &&
+  process.pkg.entrypoint.length > 0;
+
 // Verify we can require a relative module from within the worker
 let helperResult;
 try {
@@ -19,5 +29,6 @@ parentPort.postMessage({
   echo: workerData.message,
   hasFilename,
   hasDirname,
+  hasProcessPkg,
   helperResult,
 });


### PR DESCRIPTION
## Summary

- SEA worker threads were missing the `process.pkg` compatibility object that classic (non-SEA) pkg sets on every thread, so userland checks like `'pkg' in process` saw `undefined` inside workers.
- Userland code that gates on this (e.g. picking `process.cwd()` vs `__dirname` for runtime paths) silently routed writes into the read-only snapshot — a pino transport running in a worker thread would hit `/snapshot/.../<logs-dir>`, hang forever on the `open` event, and surface only as the misleading `the worker has exited` error from `thread-stream`'s writes on the main thread.
- Mirror the main-thread `shared.setupProcessPkg(...)` call in `sea-worker-entry.js` so `process.pkg` is populated consistently across threads.

## Why

Classic pkg's `bootstrap.js` runs end-to-end in both main and worker threads, so `setupProcessPkg` has always been called in workers too. The SEA worker entry was a lean rewrite that only mounted the VFS — it dropped this by oversight. Restoring parity is the least-surprising fix and preserves the `process.pkg` contract userland libraries already rely on.

## Test plan

- [x] Extend `test/test-90-sea-worker-threads` to assert `process.pkg.entrypoint` is populated inside the worker so this cannot silently regress.
- [x] `yarn build && node test/test.js node22 no-npm "test-9*-sea*"` — all SEA tests pass (test-90 through test-94).
- [x] Reproduced the original "the worker has exited" failure on a real app (pino + thread-stream + custom file transport that routes its log dir through an `isPkg()` helper), confirmed this patch fixes it end-to-end: log file is written and no hung worker.
- [x] `yarn lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)