### PR TITLE
test(fetch-all): track supported node majors, drop node20

### DIFF
--- a/test/test-42-fetch-all/main.js
+++ b/test/test-42-fetch-all/main.js
@@ -15,7 +15,7 @@ function nodeRangeToNodeVersion(nodeRange) {
 const platformsToTest = ['win', 'linux', 'macos'];
 
 for (const platform of platformsToTest) {
-  const nodeRanges = ['node20', 'node22'];
+  const nodeRanges = ['node22', 'node24'];
   for (const nodeRange of nodeRanges) {
     const archs = ['x64'];
     if (platform === 'linux' || platform === 'macos') archs.push('arm64');


### PR DESCRIPTION
## Problem

The entire `test:host` CI suite has been failing on `main` since the pkg-fetch **3.6.3** bump (#277). `test:host` is the only job that runs the host-only test set (`only-npm`); `test:22`/`test:24` use `no-npm` and exclude it, so they stayed green and masked the breakage.

The single failing test is `test-42-fetch-all`, which hard-codes `['node20', 'node22']`. pkg-fetch **3.6.x no longer publishes prebuilt `node20` binaries** (the 3.6 line ships 22/24/26), so the fetch 404s and then fails the source-build fallback:

```
Error! 404: Not Found
Not found in remote cache: {"tag":"v3.6","name":"node-v20.20.2-win-x64"}
Building base binary from source: built-v20.20.2-win-x64
Error! Not able to build for 'win' here, only for 'linux'
```

## Fix

Update the fetched node ranges to `['node22', 'node24']` — the versions pkg-fetch actually ships and the project's supported range (Node 22+). This matches the test's documented purpose ("verifies patches exist for all Node.js versions").

```diff
-  const nodeRanges = ['node20', 'node22'];
+  const nodeRanges = ['node22', 'node24'];
```

## Verification

- Verified node22 + node24 prebuilts exist for the full `win`/`linux`/`macos` × `x64`/`arm64` matrix the test covers.
- Ran the full host suite locally: **21/21 pass** (was 20/21, only `test-42-fetch-all` failing).
- `test-42-fetch-all` alone passes in ~15s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)